### PR TITLE
Add frontmatter to docs for docusaurus

### DIFF
--- a/docs/riff.md
+++ b/docs/riff.md
@@ -1,3 +1,7 @@
+---
+id: riff
+title: "riff"
+---
 ## riff
 
 riff is for functions

--- a/docs/riff_application.md
+++ b/docs/riff_application.md
@@ -1,3 +1,7 @@
+---
+id: riff-application
+title: "riff application"
+---
 ## riff application
 
 applications built from source using application buildpacks

--- a/docs/riff_application_create.md
+++ b/docs/riff_application_create.md
@@ -1,3 +1,7 @@
+---
+id: riff-application-create
+title: "riff application create"
+---
 ## riff application create
 
 create an application from source

--- a/docs/riff_application_delete.md
+++ b/docs/riff_application_delete.md
@@ -1,3 +1,7 @@
+---
+id: riff-application-delete
+title: "riff application delete"
+---
 ## riff application delete
 
 delete application(s)

--- a/docs/riff_application_list.md
+++ b/docs/riff_application_list.md
@@ -1,3 +1,7 @@
+---
+id: riff-application-list
+title: "riff application list"
+---
 ## riff application list
 
 table listing of applications

--- a/docs/riff_application_status.md
+++ b/docs/riff_application_status.md
@@ -1,3 +1,7 @@
+---
+id: riff-application-status
+title: "riff application status"
+---
 ## riff application status
 
 show application status

--- a/docs/riff_application_tail.md
+++ b/docs/riff_application_tail.md
@@ -1,3 +1,7 @@
+---
+id: riff-application-tail
+title: "riff application tail"
+---
 ## riff application tail
 
 watch build logs

--- a/docs/riff_completion.md
+++ b/docs/riff_completion.md
@@ -1,3 +1,7 @@
+---
+id: riff-completion
+title: "riff completion"
+---
 ## riff completion
 
 generate shell completion script

--- a/docs/riff_credential.md
+++ b/docs/riff_credential.md
@@ -1,3 +1,7 @@
+---
+id: riff-credential
+title: "riff credential"
+---
 ## riff credential
 
 credentials for container registries

--- a/docs/riff_credential_apply.md
+++ b/docs/riff_credential_apply.md
@@ -1,3 +1,7 @@
+---
+id: riff-credential-apply
+title: "riff credential apply"
+---
 ## riff credential apply
 
 create or update credentials for a container registry

--- a/docs/riff_credential_delete.md
+++ b/docs/riff_credential_delete.md
@@ -1,3 +1,7 @@
+---
+id: riff-credential-delete
+title: "riff credential delete"
+---
 ## riff credential delete
 
 delete credential(s)

--- a/docs/riff_credential_list.md
+++ b/docs/riff_credential_list.md
@@ -1,3 +1,7 @@
+---
+id: riff-credential-list
+title: "riff credential list"
+---
 ## riff credential list
 
 table listing of credentials

--- a/docs/riff_doctor.md
+++ b/docs/riff_doctor.md
@@ -1,3 +1,7 @@
+---
+id: riff-doctor
+title: "riff doctor"
+---
 ## riff doctor
 
 check riff's requirements are installed

--- a/docs/riff_function.md
+++ b/docs/riff_function.md
@@ -1,3 +1,7 @@
+---
+id: riff-function
+title: "riff function"
+---
 ## riff function
 
 functions built from source using function buildpacks

--- a/docs/riff_function_create.md
+++ b/docs/riff_function_create.md
@@ -1,3 +1,7 @@
+---
+id: riff-function-create
+title: "riff function create"
+---
 ## riff function create
 
 create a function from source

--- a/docs/riff_function_delete.md
+++ b/docs/riff_function_delete.md
@@ -1,3 +1,7 @@
+---
+id: riff-function-delete
+title: "riff function delete"
+---
 ## riff function delete
 
 delete function(s)

--- a/docs/riff_function_list.md
+++ b/docs/riff_function_list.md
@@ -1,3 +1,7 @@
+---
+id: riff-function-list
+title: "riff function list"
+---
 ## riff function list
 
 table listing of functions

--- a/docs/riff_function_status.md
+++ b/docs/riff_function_status.md
@@ -1,3 +1,7 @@
+---
+id: riff-function-status
+title: "riff function status"
+---
 ## riff function status
 
 show function status

--- a/docs/riff_function_tail.md
+++ b/docs/riff_function_tail.md
@@ -1,3 +1,7 @@
+---
+id: riff-function-tail
+title: "riff function tail"
+---
 ## riff function tail
 
 watch build logs

--- a/docs/riff_handler.md
+++ b/docs/riff_handler.md
@@ -1,3 +1,7 @@
+---
+id: riff-handler
+title: "riff handler"
+---
 ## riff handler
 
 handlers map HTTP requests to applications, functions or images

--- a/docs/riff_handler_create.md
+++ b/docs/riff_handler_create.md
@@ -1,3 +1,7 @@
+---
+id: riff-handler-create
+title: "riff handler create"
+---
 ## riff handler create
 
 create a handler to map HTTP requests to an application, function or image

--- a/docs/riff_handler_delete.md
+++ b/docs/riff_handler_delete.md
@@ -1,3 +1,7 @@
+---
+id: riff-handler-delete
+title: "riff handler delete"
+---
 ## riff handler delete
 
 delete handler(s)

--- a/docs/riff_handler_list.md
+++ b/docs/riff_handler_list.md
@@ -1,3 +1,7 @@
+---
+id: riff-handler-list
+title: "riff handler list"
+---
 ## riff handler list
 
 table listing of handlers

--- a/docs/riff_handler_status.md
+++ b/docs/riff_handler_status.md
@@ -1,3 +1,7 @@
+---
+id: riff-handler-status
+title: "riff handler status"
+---
 ## riff handler status
 
 show handler status

--- a/docs/riff_handler_tail.md
+++ b/docs/riff_handler_tail.md
@@ -1,3 +1,7 @@
+---
+id: riff-handler-tail
+title: "riff handler tail"
+---
 ## riff handler tail
 
 watch handler logs

--- a/docs/riff_processor.md
+++ b/docs/riff_processor.md
@@ -1,3 +1,7 @@
+---
+id: riff-processor
+title: "riff processor"
+---
 ## riff processor
 
 processors apply functions to messages on streams

--- a/docs/riff_processor_create.md
+++ b/docs/riff_processor_create.md
@@ -1,3 +1,7 @@
+---
+id: riff-processor-create
+title: "riff processor create"
+---
 ## riff processor create
 
 create a processor to apply a function to messages on streams

--- a/docs/riff_processor_delete.md
+++ b/docs/riff_processor_delete.md
@@ -1,3 +1,7 @@
+---
+id: riff-processor-delete
+title: "riff processor delete"
+---
 ## riff processor delete
 
 delete processor(s)

--- a/docs/riff_processor_list.md
+++ b/docs/riff_processor_list.md
@@ -1,3 +1,7 @@
+---
+id: riff-processor-list
+title: "riff processor list"
+---
 ## riff processor list
 
 table listing of processors

--- a/docs/riff_processor_status.md
+++ b/docs/riff_processor_status.md
@@ -1,3 +1,7 @@
+---
+id: riff-processor-status
+title: "riff processor status"
+---
 ## riff processor status
 
 show processor status

--- a/docs/riff_processor_tail.md
+++ b/docs/riff_processor_tail.md
@@ -1,3 +1,7 @@
+---
+id: riff-processor-tail
+title: "riff processor tail"
+---
 ## riff processor tail
 
 watch processor logs

--- a/docs/riff_stream.md
+++ b/docs/riff_stream.md
@@ -1,3 +1,7 @@
+---
+id: riff-stream
+title: "riff stream"
+---
 ## riff stream
 
 streams of messages

--- a/docs/riff_stream_create.md
+++ b/docs/riff_stream_create.md
@@ -1,3 +1,7 @@
+---
+id: riff-stream-create
+title: "riff stream create"
+---
 ## riff stream create
 
 create a stream of messages

--- a/docs/riff_stream_delete.md
+++ b/docs/riff_stream_delete.md
@@ -1,3 +1,7 @@
+---
+id: riff-stream-delete
+title: "riff stream delete"
+---
 ## riff stream delete
 
 delete stream(s)

--- a/docs/riff_stream_list.md
+++ b/docs/riff_stream_list.md
@@ -1,3 +1,7 @@
+---
+id: riff-stream-list
+title: "riff stream list"
+---
 ## riff stream list
 
 table listing of streams

--- a/docs/riff_stream_status.md
+++ b/docs/riff_stream_status.md
@@ -1,3 +1,7 @@
+---
+id: riff-stream-status
+title: "riff stream status"
+---
 ## riff stream status
 
 show stream status

--- a/pkg/riff/commands/docs.go
+++ b/pkg/riff/commands/docs.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/projectriff/cli/pkg/cli"
@@ -45,6 +47,27 @@ func (opts *DocsOptions) Validate(ctx context.Context) *cli.FieldError {
 	return errs
 }
 
+// frontmatter for docusaurus markdown
+// per https://docusaurus.io/docs/en/doc-markdown#documents
+const fmTemplate = `---
+id: %s
+title: "%s"
+---
+`
+
+func filePrepender(filename string) string {
+	name := filepath.Base(filename)
+	base := strings.TrimSuffix(name, path.Ext(name))
+	id := strings.Replace(base, "_", "-", -1)
+	title := strings.Replace(base, "_", " ", -1)
+
+	return fmt.Sprintf(fmTemplate, id, title)
+}
+
+func linkHandler(name string) string {
+	return name
+}
+
 func NewDocsCommand(ctx context.Context, c *cli.Config) *cobra.Command {
 	opts := &DocsOptions{}
 
@@ -68,7 +91,7 @@ func NewDocsCommand(ctx context.Context, c *cli.Config) *cobra.Command {
 				noColorFlag.DefValue = "false"
 			}
 
-			return doc.GenMarkdownTree(root, opts.Directory)
+			return doc.GenMarkdownTreeCustom(root, opts.Directory, filePrepender, linkHandler)
 		},
 	}
 


### PR DESCRIPTION
This will allow the generated CLI docs to be published as part of a docusaurus documentation website.

https://docusaurus.io/docs/en/doc-markdown#documents 