### PR TITLE
Cleanup cruft in the riff/commands package

### DIFF
--- a/pkg/riff/commands/application_list.go
+++ b/pkg/riff/commands/application_list.go
@@ -62,9 +62,9 @@ func (opts *ApplicationListOptions) Exec(ctx context.Context, c *cli.Config) err
 	tablePrinter := printers.NewTablePrinter(printers.PrintOptions{
 		WithNamespace: opts.AllNamespaces,
 	}).With(func(h printers.PrintHandler) {
-		columns := printApplicationColumns()
-		h.TableHandler(columns, printApplicationList)
-		h.TableHandler(columns, printApplication)
+		columns := opts.printColumns()
+		h.TableHandler(columns, opts.printList)
+		h.TableHandler(columns, opts.print)
 	})
 
 	applications = applications.DeepCopy()
@@ -100,10 +100,10 @@ For detail regarding the status of a single application, run:
 	return cmd
 }
 
-func printApplicationList(applications *buildv1alpha1.ApplicationList, opts printers.PrintOptions) ([]metav1beta1.TableRow, error) {
+func (opts *ApplicationListOptions) printList(applications *buildv1alpha1.ApplicationList, printOpts printers.PrintOptions) ([]metav1beta1.TableRow, error) {
 	rows := make([]metav1beta1.TableRow, 0, len(applications.Items))
 	for i := range applications.Items {
-		r, err := printApplication(&applications.Items[i], opts)
+		r, err := opts.print(&applications.Items[i], printOpts)
 		if err != nil {
 			return nil, err
 		}
@@ -112,7 +112,7 @@ func printApplicationList(applications *buildv1alpha1.ApplicationList, opts prin
 	return rows, nil
 }
 
-func printApplication(application *buildv1alpha1.Application, opts printers.PrintOptions) ([]metav1beta1.TableRow, error) {
+func (opts *ApplicationListOptions) print(application *buildv1alpha1.Application, _ printers.PrintOptions) ([]metav1beta1.TableRow, error) {
 	now := time.Now()
 	row := metav1beta1.TableRow{
 		Object: runtime.RawExtension{Object: application},
@@ -126,7 +126,7 @@ func printApplication(application *buildv1alpha1.Application, opts printers.Prin
 	return []metav1beta1.TableRow{row}, nil
 }
 
-func printApplicationColumns() []metav1beta1.TableColumnDefinition {
+func (opts *ApplicationListOptions) printColumns() []metav1beta1.TableColumnDefinition {
 	return []metav1beta1.TableColumnDefinition{
 		{Name: "Name", Type: "string"},
 		{Name: "Latest Image", Type: "string"},

--- a/pkg/riff/commands/credential_list.go
+++ b/pkg/riff/commands/credential_list.go
@@ -65,9 +65,9 @@ func (opts *CredentialListOptions) Exec(ctx context.Context, c *cli.Config) erro
 	tablePrinter := printers.NewTablePrinter(printers.PrintOptions{
 		WithNamespace: opts.AllNamespaces,
 	}).With(func(h printers.PrintHandler) {
-		columns := printCredentialColumns()
-		h.TableHandler(columns, printCredentialList)
-		h.TableHandler(columns, printCredential)
+		columns := opts.printColumns()
+		h.TableHandler(columns, opts.printList)
+		h.TableHandler(columns, opts.print)
 	})
 
 	secrets = secrets.DeepCopy()
@@ -99,10 +99,10 @@ List credentials in a namespace or across all namespaces.
 	return cmd
 }
 
-func printCredentialList(credentials *corev1.SecretList, opts printers.PrintOptions) ([]metav1beta1.TableRow, error) {
+func (opts *CredentialListOptions) printList(credentials *corev1.SecretList, printOpts printers.PrintOptions) ([]metav1beta1.TableRow, error) {
 	rows := make([]metav1beta1.TableRow, 0, len(credentials.Items))
 	for i := range credentials.Items {
-		r, err := printCredential(&credentials.Items[i], opts)
+		r, err := opts.print(&credentials.Items[i], printOpts)
 		if err != nil {
 			return nil, err
 		}
@@ -111,7 +111,7 @@ func printCredentialList(credentials *corev1.SecretList, opts printers.PrintOpti
 	return rows, nil
 }
 
-func printCredential(credential *corev1.Secret, opts printers.PrintOptions) ([]metav1beta1.TableRow, error) {
+func (opts *CredentialListOptions) print(credential *corev1.Secret, _ printers.PrintOptions) ([]metav1beta1.TableRow, error) {
 	now := time.Now()
 	row := metav1beta1.TableRow{
 		Object: runtime.RawExtension{Object: credential.DeepCopy()},
@@ -125,7 +125,7 @@ func printCredential(credential *corev1.Secret, opts printers.PrintOptions) ([]m
 	return []metav1beta1.TableRow{row}, nil
 }
 
-func printCredentialColumns() []metav1beta1.TableColumnDefinition {
+func (opts *CredentialListOptions) printColumns() []metav1beta1.TableColumnDefinition {
 	return []metav1beta1.TableColumnDefinition{
 		{Name: "Name", Type: "string"},
 		{Name: "Type", Type: "string"},

--- a/pkg/riff/commands/docs.go
+++ b/pkg/riff/commands/docs.go
@@ -47,27 +47,6 @@ func (opts *DocsOptions) Validate(ctx context.Context) *cli.FieldError {
 	return errs
 }
 
-// frontmatter for docusaurus markdown
-// per https://docusaurus.io/docs/en/doc-markdown#documents
-const fmTemplate = `---
-id: %s
-title: "%s"
----
-`
-
-func filePrepender(filename string) string {
-	name := filepath.Base(filename)
-	base := strings.TrimSuffix(name, path.Ext(name))
-	id := strings.Replace(base, "_", "-", -1)
-	title := strings.Replace(base, "_", " ", -1)
-
-	return fmt.Sprintf(fmTemplate, id, title)
-}
-
-func linkHandler(name string) string {
-	return name
-}
-
 func NewDocsCommand(ctx context.Context, c *cli.Config) *cobra.Command {
 	opts := &DocsOptions{}
 
@@ -88,7 +67,27 @@ func NewDocsCommand(ctx context.Context, c *cli.Config) *cobra.Command {
 				noColorFlag.DefValue = "false"
 			}
 
-			return doc.GenMarkdownTreeCustom(root, opts.Directory, filePrepender, linkHandler)
+			return doc.GenMarkdownTreeCustom(root, opts.Directory,
+				func(filename string) string {
+					name := filepath.Base(filename)
+					base := strings.TrimSuffix(name, path.Ext(name))
+					id := strings.Replace(base, "_", "-", -1)
+					title := strings.Replace(base, "_", " ", -1)
+
+					// frontmatter for docusaurus markdown
+					// per https://docusaurus.io/docs/en/doc-markdown#documents
+					fmTemplate := `---
+id: %s
+title: "%s"
+---
+`
+
+					return fmt.Sprintf(fmTemplate, id, title)
+				},
+				func(name string) string {
+					return name
+				},
+			)
 		},
 	}
 

--- a/pkg/riff/commands/function_list.go
+++ b/pkg/riff/commands/function_list.go
@@ -62,9 +62,9 @@ func (opts *FunctionListOptions) Exec(ctx context.Context, c *cli.Config) error 
 	tablePrinter := printers.NewTablePrinter(printers.PrintOptions{
 		WithNamespace: opts.AllNamespaces,
 	}).With(func(h printers.PrintHandler) {
-		columns := printFunctionColumns()
-		h.TableHandler(columns, printFunctionList)
-		h.TableHandler(columns, printFunction)
+		columns := opts.printColumns()
+		h.TableHandler(columns, opts.printList)
+		h.TableHandler(columns, opts.print)
 	})
 
 	functions = functions.DeepCopy()
@@ -100,10 +100,10 @@ For detail regarding the status of a single function, run:
 	return cmd
 }
 
-func printFunctionList(functions *buildv1alpha1.FunctionList, opts printers.PrintOptions) ([]metav1beta1.TableRow, error) {
+func (opts *FunctionListOptions) printList(functions *buildv1alpha1.FunctionList, printOpts printers.PrintOptions) ([]metav1beta1.TableRow, error) {
 	rows := make([]metav1beta1.TableRow, 0, len(functions.Items))
 	for i := range functions.Items {
-		r, err := printFunction(&functions.Items[i], opts)
+		r, err := opts.print(&functions.Items[i], printOpts)
 		if err != nil {
 			return nil, err
 		}
@@ -112,7 +112,7 @@ func printFunctionList(functions *buildv1alpha1.FunctionList, opts printers.Prin
 	return rows, nil
 }
 
-func printFunction(function *buildv1alpha1.Function, opts printers.PrintOptions) ([]metav1beta1.TableRow, error) {
+func (opts *FunctionListOptions) print(function *buildv1alpha1.Function, _ printers.PrintOptions) ([]metav1beta1.TableRow, error) {
 	now := time.Now()
 	row := metav1beta1.TableRow{
 		Object: runtime.RawExtension{Object: function},
@@ -129,7 +129,7 @@ func printFunction(function *buildv1alpha1.Function, opts printers.PrintOptions)
 	return []metav1beta1.TableRow{row}, nil
 }
 
-func printFunctionColumns() []metav1beta1.TableColumnDefinition {
+func (opts *FunctionListOptions) printColumns() []metav1beta1.TableColumnDefinition {
 	return []metav1beta1.TableColumnDefinition{
 		{Name: "Name", Type: "string"},
 		{Name: "Latest Image", Type: "string"},

--- a/pkg/riff/commands/handler_invoke.go
+++ b/pkg/riff/commands/handler_invoke.go
@@ -61,7 +61,7 @@ func (opts *HandlerInvokeOptions) Exec(ctx context.Context, c *cli.Config) error
 		return fmt.Errorf("handler %q is not ready", opts.Name)
 	}
 
-	ingress, err := ingressServiceHost(c)
+	ingress, err := opts.ingressServiceHost(c)
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ This command is not supported and may be removed in the future.
 	return cmd
 }
 
-func ingressServiceHost(c *cli.Config) (string, error) {
+func (opts *HandlerInvokeOptions) ingressServiceHost(c *cli.Config) (string, error) {
 	// TODO allow setting ingress manually
 	svc, err := c.Core().Services("istio-system").Get("istio-ingressgateway", metav1.GetOptions{})
 	if err != nil {

--- a/pkg/riff/commands/processor_list.go
+++ b/pkg/riff/commands/processor_list.go
@@ -62,9 +62,9 @@ func (opts *ProcessorListOptions) Exec(ctx context.Context, c *cli.Config) error
 	tablePrinter := printers.NewTablePrinter(printers.PrintOptions{
 		WithNamespace: opts.AllNamespaces,
 	}).With(func(h printers.PrintHandler) {
-		columns := printProcessorColumns()
-		h.TableHandler(columns, printProcessorList)
-		h.TableHandler(columns, printProcessor)
+		columns := opts.printColumns()
+		h.TableHandler(columns, opts.printList)
+		h.TableHandler(columns, opts.print)
 	})
 
 	processors = processors.DeepCopy()
@@ -100,10 +100,10 @@ For detail regarding the status of a single processor, run:
 	return cmd
 }
 
-func printProcessorList(processors *streamv1alpha1.ProcessorList, opts printers.PrintOptions) ([]metav1beta1.TableRow, error) {
+func (opts *ProcessorListOptions) printList(processors *streamv1alpha1.ProcessorList, printOpts printers.PrintOptions) ([]metav1beta1.TableRow, error) {
 	rows := make([]metav1beta1.TableRow, 0, len(processors.Items))
 	for i := range processors.Items {
-		r, err := printProcessor(&processors.Items[i], opts)
+		r, err := opts.print(&processors.Items[i], printOpts)
 		if err != nil {
 			return nil, err
 		}
@@ -112,7 +112,7 @@ func printProcessorList(processors *streamv1alpha1.ProcessorList, opts printers.
 	return rows, nil
 }
 
-func printProcessor(processor *streamv1alpha1.Processor, opts printers.PrintOptions) ([]metav1beta1.TableRow, error) {
+func (opts *ProcessorListOptions) print(processor *streamv1alpha1.Processor, _ printers.PrintOptions) ([]metav1beta1.TableRow, error) {
 	now := time.Now()
 	row := metav1beta1.TableRow{
 		Object: runtime.RawExtension{Object: processor},
@@ -128,7 +128,7 @@ func printProcessor(processor *streamv1alpha1.Processor, opts printers.PrintOpti
 	return []metav1beta1.TableRow{row}, nil
 }
 
-func printProcessorColumns() []metav1beta1.TableColumnDefinition {
+func (opts *ProcessorListOptions) printColumns() []metav1beta1.TableColumnDefinition {
 	return []metav1beta1.TableColumnDefinition{
 		{Name: "Name", Type: "string"},
 		{Name: "Function", Type: "string"},

--- a/pkg/riff/commands/stream_list.go
+++ b/pkg/riff/commands/stream_list.go
@@ -62,9 +62,9 @@ func (opts *StreamListOptions) Exec(ctx context.Context, c *cli.Config) error {
 	tablePrinter := printers.NewTablePrinter(printers.PrintOptions{
 		WithNamespace: opts.AllNamespaces,
 	}).With(func(h printers.PrintHandler) {
-		columns := printStreamColumns()
-		h.TableHandler(columns, printStreamList)
-		h.TableHandler(columns, printStream)
+		columns := opts.printColumns()
+		h.TableHandler(columns, opts.printList)
+		h.TableHandler(columns, opts.print)
 	})
 
 	streams = streams.DeepCopy()
@@ -100,10 +100,10 @@ For detail regarding the status of a single stream, run:
 	return cmd
 }
 
-func printStreamList(streams *streamv1alpha1.StreamList, opts printers.PrintOptions) ([]metav1beta1.TableRow, error) {
+func (opts *StreamListOptions) printList(streams *streamv1alpha1.StreamList, printOpts printers.PrintOptions) ([]metav1beta1.TableRow, error) {
 	rows := make([]metav1beta1.TableRow, 0, len(streams.Items))
 	for i := range streams.Items {
-		r, err := printStream(&streams.Items[i], opts)
+		r, err := opts.print(&streams.Items[i], printOpts)
 		if err != nil {
 			return nil, err
 		}
@@ -112,7 +112,7 @@ func printStreamList(streams *streamv1alpha1.StreamList, opts printers.PrintOpti
 	return rows, nil
 }
 
-func printStream(stream *streamv1alpha1.Stream, opts printers.PrintOptions) ([]metav1beta1.TableRow, error) {
+func (opts *StreamListOptions) print(stream *streamv1alpha1.Stream, _ printers.PrintOptions) ([]metav1beta1.TableRow, error) {
 	now := time.Now()
 	row := metav1beta1.TableRow{
 		Object: runtime.RawExtension{Object: stream},
@@ -129,7 +129,7 @@ func printStream(stream *streamv1alpha1.Stream, opts printers.PrintOptions) ([]m
 	return []metav1beta1.TableRow{row}, nil
 }
 
-func printStreamColumns() []metav1beta1.TableColumnDefinition {
+func (opts *StreamListOptions) printColumns() []metav1beta1.TableColumnDefinition {
 	return []metav1beta1.TableColumnDefinition{
 		{Name: "Name", Type: "string"},
 		{Name: "Topic", Type: "string"},


### PR DESCRIPTION
This package is large enough that symbols, even if unexported, need to
have meaningful names that will not collide with another command. In
most cases, it's easier and safer to inline declarations or attach
functions them to a struct.