### PR TITLE
Use helm to install riff for FATS tests

### DIFF
--- a/ci/fats-cleanup.sh
+++ b/ci/fats-cleanup.sh
@@ -7,9 +7,7 @@ fats_dir=`dirname "${BASH_SOURCE[0]}"`/fats
 # attempt to cleanup fats
 if [ -d "$fats_dir" ]; then
   echo "Uninstall riff system"
-  duffle_k8s_service_account=${duffle_k8s_service_account:-duffle-runtime}
-  duffle_k8s_namespace=${duffle_k8s_namespace:-kube-system}
-  SERVICE_ACCOUNT=${duffle_k8s_service_account} KUBE_NAMESPACE=${duffle_k8s_namespace} duffle uninstall riff -d k8s || true
+  helm delete riff --purge || true
   kubectl delete namespace $NAMESPACE || true
 
   source $fats_dir/cleanup.sh

--- a/ci/fats-cleanup.sh
+++ b/ci/fats-cleanup.sh
@@ -7,8 +7,18 @@ fats_dir=`dirname "${BASH_SOURCE[0]}"`/fats
 # attempt to cleanup fats
 if [ -d "$fats_dir" ]; then
   echo "Uninstall riff system"
-  helm delete riff --purge || true
-  kubectl delete namespace $NAMESPACE || true
+  kubectl delete namespace $NAMESPACE
+  
+  helm delete --purge riff
+  kubectl delete customresourcedefinitions.apiextensions.k8s.io -l app.kubernetes.io/managed-by=Tiller,app.kubernetes.io/instance=riff
+
+  helm delete --purge istio
+  kubectl delete customresourcedefinitions.apiextensions.k8s.io -l app.kubernetes.io/managed-by=Tiller,app.kubernetes.io/instance=istio
+  kubectl delete namespace istio-system
+
+  helm reset
+  kubectl delete serviceaccount tiller -n kube-system
+  kubectl delete clusterrolebinding tiller
 
   source $fats_dir/cleanup.sh
 fi

--- a/ci/fats.sh
+++ b/ci/fats.sh
@@ -36,7 +36,7 @@ $fats_dir/install.sh helm
 
 kubectl create serviceaccount tiller -n kube-system
 kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount kube-system:tiller
-helm init --service-account tiller
+helm init --wait --service-account tiller
 
 helm repo add projectriff https://projectriff.storage.googleapis.com/charts/releases
 helm repo update

--- a/ci/fats.sh
+++ b/ci/fats.sh
@@ -41,7 +41,8 @@ helm init --wait --service-account tiller
 helm repo add projectriff https://projectriff.storage.googleapis.com/charts/releases
 helm repo update
 
-helm install projectriff/riff --name riff --set istio.enabled=true --set global.k8s.service.type=${K8S_SERVICE_TYPE} --devel
+helm install projectriff/istio --name istio --namespace istio-system --devel --wait --set istio.enabled=true --set gateways.istio-ingressgateway.type=${K8S_SERVICE_TYPE}
+helm install projectriff/riff --name riff --devel
 
 # health checks
 echo "Checking for ready ingress"

--- a/ci/fats.sh
+++ b/ci/fats.sh
@@ -41,7 +41,7 @@ helm init --wait --service-account tiller
 helm repo add projectriff https://projectriff.storage.googleapis.com/charts/releases
 helm repo update
 
-helm install projectriff/projectriff-riff --name riff --set istio.enabled=true --set global.k8s.service.type=${K8S_SERVICE_TYPE} --devel
+helm install projectriff/riff --name riff --set istio.enabled=true --set global.k8s.service.type=${K8S_SERVICE_TYPE} --devel
 
 # health checks
 echo "Checking for ready ingress"


### PR DESCRIPTION
riff releases have both a helm chart and a duffle bundle to manage
installation. Either will work just fine for the purpose of riff CLI
acceptance tests. At this point, I'm choosing to use helm over duffle
because it is more widely known and stable.