### PR TITLE
Include command arguments in help

### DIFF
--- a/docs/riff_application_create.md
+++ b/docs/riff_application_create.md
@@ -18,7 +18,7 @@ command (in the future, builds from local source may also be run in the
 cluster).
 
 ```
-riff application create [flags]
+riff application create <name> [flags]
 ```
 
 ### Examples

--- a/docs/riff_application_delete.md
+++ b/docs/riff_application_delete.md
@@ -16,7 +16,7 @@ built image. A new application created with the same name will automatically be
 discovered by the handler.
 
 ```
-riff application delete [flags]
+riff application delete <name(s)> [flags]
 ```
 
 ### Examples

--- a/docs/riff_application_status.md
+++ b/docs/riff_application_status.md
@@ -16,7 +16,7 @@ may be: "True", "False" or "Unknown". An "Unknown" status is common while the
 application is processed or a build is in progress.
 
 ```
-riff application status [flags]
+riff application status <name> [flags]
 ```
 
 ### Examples

--- a/docs/riff_application_tail.md
+++ b/docs/riff_application_tail.md
@@ -15,7 +15,7 @@ As new builds are started, the logs are displayed. To show historical logs use
 --since.
 
 ```
-riff application tail [flags]
+riff application tail <name> [flags]
 ```
 
 ### Examples

--- a/docs/riff_credential_apply.md
+++ b/docs/riff_credential_apply.md
@@ -25,7 +25,7 @@ While multiple credentials can be created in a single namespace, only a single
 default image prefix can be set.
 
 ```
-riff credential apply [flags]
+riff credential apply <name> [flags]
 ```
 
 ### Examples

--- a/docs/riff_credential_delete.md
+++ b/docs/riff_credential_delete.md
@@ -15,7 +15,7 @@ the credential to fail unless another credential for the same registry is
 available.
 
 ```
-riff credential delete [flags]
+riff credential delete <name(s)> [flags]
 ```
 
 ### Examples

--- a/docs/riff_function_create.md
+++ b/docs/riff_function_create.md
@@ -35,7 +35,7 @@ The riff.toml file takes the form:
 	handler = "<function handler>"
 
 ```
-riff function create [flags]
+riff function create <name> [flags]
 ```
 
 ### Examples

--- a/docs/riff_function_delete.md
+++ b/docs/riff_function_delete.md
@@ -16,7 +16,7 @@ use the last built image. A new function created with the same name will
 automatically be discovered by the handler or processor.
 
 ```
-riff function delete [flags]
+riff function delete <name(s)> [flags]
 ```
 
 ### Examples

--- a/docs/riff_function_status.md
+++ b/docs/riff_function_status.md
@@ -16,7 +16,7 @@ may be: "True", "False" or "Unknown". An "Unknown" status is common while the
 function is processed or a build is in progress.
 
 ```
-riff function status [flags]
+riff function status <name> [flags]
 ```
 
 ### Examples

--- a/docs/riff_function_tail.md
+++ b/docs/riff_function_tail.md
@@ -15,7 +15,7 @@ As new builds are started, the logs are displayed. To show historical logs use
 --since.
 
 ```
-riff function tail [flags]
+riff function tail <name> [flags]
 ```
 
 ### Examples

--- a/docs/riff_handler_create.md
+++ b/docs/riff_handler_create.md
@@ -25,7 +25,7 @@ The runtime environment can be configured by --env for static key-value pairs
 and --env-from to map values from a ConfigMap or Secret.
 
 ```
-riff handler create [flags]
+riff handler create <name> [flags]
 ```
 
 ### Examples

--- a/docs/riff_handler_delete.md
+++ b/docs/riff_handler_delete.md
@@ -15,7 +15,7 @@ the same name will start to receive new HTTP requests addressed to the same
 handler.
 
 ```
-riff handler delete [flags]
+riff handler delete <name(s)> [flags]
 ```
 
 ### Examples

--- a/docs/riff_handler_status.md
+++ b/docs/riff_handler_status.md
@@ -16,7 +16,7 @@ may be: "True", "False" or "Unknown". An "Unknown" status is common while the
 handler is processed.
 
 ```
-riff handler status [flags]
+riff handler status <name> [flags]
 ```
 
 ### Examples

--- a/docs/riff_handler_tail.md
+++ b/docs/riff_handler_tail.md
@@ -15,7 +15,7 @@ As new handler instances are started, the logs are displayed. To show historical
 --since.
 
 ```
-riff handler tail [flags]
+riff handler tail <name> [flags]
 ```
 
 ### Examples

--- a/docs/riff_processor_create.md
+++ b/docs/riff_processor_create.md
@@ -11,7 +11,7 @@ create a processor to apply a function to messages on streams
 <todo>
 
 ```
-riff processor create [flags]
+riff processor create <name> [flags]
 ```
 
 ### Examples

--- a/docs/riff_processor_delete.md
+++ b/docs/riff_processor_delete.md
@@ -14,7 +14,7 @@ The processor will stop processing messages from the input streams and writing
 to the output streams. The streams and messages in each stream are preserved.
 
 ```
-riff processor delete [flags]
+riff processor delete <name(s)> [flags]
 ```
 
 ### Examples

--- a/docs/riff_processor_status.md
+++ b/docs/riff_processor_status.md
@@ -16,7 +16,7 @@ may be: "True", "False" or "Unknown". An "Unknown" status is common while the
 processor is processed.
 
 ```
-riff processor status [flags]
+riff processor status <name> [flags]
 ```
 
 ### Examples

--- a/docs/riff_processor_tail.md
+++ b/docs/riff_processor_tail.md
@@ -15,7 +15,7 @@ As new processor instances are started, the logs are displayed. To show historic
 --since.
 
 ```
-riff processor tail [flags]
+riff processor tail <name> [flags]
 ```
 
 ### Examples

--- a/docs/riff_stream_create.md
+++ b/docs/riff_stream_create.md
@@ -11,7 +11,7 @@ create a stream of messages
 <todo>
 
 ```
-riff stream create [flags]
+riff stream create <name> [flags]
 ```
 
 ### Examples

--- a/docs/riff_stream_delete.md
+++ b/docs/riff_stream_delete.md
@@ -15,7 +15,7 @@ the stream. Existing messages in the stream may be preserved by the underlying
 messaging middleware, depending on the implementation.
 
 ```
-riff stream delete [flags]
+riff stream delete <name(s)> [flags]
 ```
 
 ### Examples

--- a/docs/riff_stream_status.md
+++ b/docs/riff_stream_status.md
@@ -16,7 +16,7 @@ may be: "True", "False" or "Unknown". An "Unknown" status is common while the
 stream is being processed.
 
 ```
-riff stream status [flags]
+riff stream status <name> [flags]
 ```
 
 ### Examples

--- a/pkg/cli/arguments.go
+++ b/pkg/cli/arguments.go
@@ -38,9 +38,6 @@ type Arg struct {
 }
 
 func Args(cmd *cobra.Command, argDefs ...Arg) {
-	if cmd.Args != nil {
-		panic(fmt.Errorf("args redeclared for command %q", cmd.CommandPath()))
-	}
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
 		offset := 0
 
@@ -86,10 +83,6 @@ func Args(cmd *cobra.Command, argDefs ...Arg) {
 }
 
 func FormatArgs(cmd *cobra.Command) string {
-	if _, ok := cmd.Annotations["args.length"]; !ok {
-		return ""
-	}
-
 	str := ""
 	length, _ := strconv.Atoi(cmd.Annotations["args.length"])
 	for i := 0; i < length; i++ {

--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -37,6 +37,20 @@ func Sequence(items ...func(cmd *cobra.Command, args []string) error) func(*cobr
 	}
 }
 
+func Visit(cmd *cobra.Command, f func(c *cobra.Command) error) error {
+	err := f(cmd)
+	if err != nil {
+		return err
+	}
+	for _, c := range cmd.Commands() {
+		err := Visit(c, f)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func ReadStdin(c *Config, value *[]byte, prompt string) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		if terminal.IsTerminal(int(syscall.Stdin)) {

--- a/pkg/riff/commands/application.go
+++ b/pkg/riff/commands/application.go
@@ -39,7 +39,6 @@ The application resource is only responsible for converting source code into a
 container. The application container image may then be deployed as a request
 handler. See ` + "`" + c.Name + " handler --help" + "`" + ` for detail.
 `),
-		Args:    cli.Args(),
 		Aliases: []string{"applications", "app", "apps"},
 	}
 

--- a/pkg/riff/commands/application_create.go
+++ b/pkg/riff/commands/application_create.go
@@ -221,12 +221,13 @@ cluster).
 			fmt.Sprintf("%s application create my-app %s registry.example.com/image %s https://example.com/my-app.git", c.Name, cli.ImageFlagName, cli.GitRepoFlagName),
 			fmt.Sprintf("%s application create my-app %s registry.example.com/image %s ./my-app", c.Name, cli.ImageFlagName, cli.LocalPathFlagName),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NameArg(&opts.Name),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NameArg(&opts.Name),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 	cmd.Flags().StringVar(&opts.Image, cli.StripDash(cli.ImageFlagName), "_", "`repository` where the built images are pushed")

--- a/pkg/riff/commands/application_delete.go
+++ b/pkg/riff/commands/application_delete.go
@@ -82,12 +82,13 @@ discovered by the handler.
 			fmt.Sprintf("%s application delete my-application", c.Name),
 			fmt.Sprintf("%s application delete %s", c.Name, cli.AllFlagName),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NamesArg(&opts.Names),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NamesArg(&opts.Names),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 	cmd.Flags().BoolVar(&opts.All, cli.StripDash(cli.AllFlagName), false, "delete all applications within the namespace")

--- a/pkg/riff/commands/application_list.go
+++ b/pkg/riff/commands/application_list.go
@@ -90,7 +90,6 @@ For detail regarding the status of a single application, run:
 			fmt.Sprintf("%s application list", c.Name),
 			fmt.Sprintf("%s application list %s", c.Name, cli.AllNamespacesFlagName),
 		}, "\n"),
-		Args:    cli.Args(),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}

--- a/pkg/riff/commands/application_status.go
+++ b/pkg/riff/commands/application_status.go
@@ -78,12 +78,13 @@ application is processed or a build is in progress.
 		Example: strings.Join([]string{
 			fmt.Sprintf("%s application status my-application", c.Name),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NameArg(&opts.Name),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NameArg(&opts.Name),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 

--- a/pkg/riff/commands/application_tail.go
+++ b/pkg/riff/commands/application_tail.go
@@ -81,12 +81,13 @@ As new builds are started, the logs are displayed. To show historical logs use
 			fmt.Sprintf("%s application tail my-application", c.Name),
 			fmt.Sprintf("%s application tail my-application %s 1h", c.Name, cli.SinceFlagName),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NameArg(&opts.Name),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NameArg(&opts.Name),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 	cmd.Flags().StringVar(&opts.Since, cli.StripDash(cli.SinceFlagName), "", "time `duration` to start reading logs from")

--- a/pkg/riff/commands/completion.go
+++ b/pkg/riff/commands/completion.go
@@ -72,7 +72,6 @@ and needs to be placed in the appropriate directory on your system.
 			fmt.Sprintf("%s completion", c.Name),
 			fmt.Sprintf("%s completion %s zsh", c.Name, cli.ShellFlagName),
 		}, "\n"),
-		Args:    cli.Args(),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}

--- a/pkg/riff/commands/credential.go
+++ b/pkg/riff/commands/credential.go
@@ -45,7 +45,6 @@ To manage credentials, read and write access to Secrets is required for the
 namespace. To manage the default image prefix, read and write access to the
 'riff-build' ConfigMap is required for the namespace.
 `),
-		Args:    cli.Args(),
 		Aliases: []string{"credentials", "cred", "creds"},
 	}
 

--- a/pkg/riff/commands/credential_apply.go
+++ b/pkg/riff/commands/credential_apply.go
@@ -169,9 +169,6 @@ default image prefix can be set.
 			fmt.Sprintf("%s credential apply my-registry-creds %s http://registry.example.com %s my-username", c.Name, cli.RegistryFlagName, cli.RegistryUserFlagName),
 			fmt.Sprintf("%s credential apply my-registry-creds %s http://registry.example.com %s my-username %s registry.example.com/my-username", c.Name, cli.RegistryFlagName, cli.RegistryUserFlagName, cli.DefaultImagePrefixFlagName),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NameArg(&opts.Name),
-		),
 		PreRunE: cli.Sequence(
 			func(cmd *cobra.Command, args []string) error {
 				if opts.DockerHubId != "" {
@@ -186,6 +183,10 @@ default image prefix can be set.
 		),
 		RunE: cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NameArg(&opts.Name),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 	cmd.Flags().StringVar(&opts.DockerHubId, cli.StripDash(cli.DockerHubFlagName), "", "Docker Hub `username`, the password must be provided via stdin")

--- a/pkg/riff/commands/credential_delete.go
+++ b/pkg/riff/commands/credential_delete.go
@@ -86,12 +86,13 @@ available.
 			fmt.Sprintf("%s credential delete my-creds", c.Name),
 			fmt.Sprintf("%s credential delete %s ", c.Name, cli.AllFlagName),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NamesArg(&opts.Names),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NamesArg(&opts.Names),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 	cmd.Flags().BoolVar(&opts.All, cli.StripDash(cli.AllFlagName), false, "delete all credentials within the namespace")

--- a/pkg/riff/commands/credential_list.go
+++ b/pkg/riff/commands/credential_list.go
@@ -89,7 +89,6 @@ List credentials in a namespace or across all namespaces.
 			fmt.Sprintf("%s credential list", c.Name),
 			fmt.Sprintf("%s credential list %s", c.Name, cli.AllNamespacesFlagName),
 		}, "\n"),
-		Args:    cli.Args(),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}

--- a/pkg/riff/commands/doctor.go
+++ b/pkg/riff/commands/doctor.go
@@ -101,7 +101,6 @@ The doctor checks that necessary system components are installed.
 The doctor is not a tool for monitoring the health of the cluster.
 `),
 		Example: "riff doctor",
-		Args:    cli.Args(),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}

--- a/pkg/riff/commands/function.go
+++ b/pkg/riff/commands/function.go
@@ -49,7 +49,6 @@ the source code. Unlike applications, functions:
 - limited to a single responsibility
 
 `),
-		Args:    cli.Args(),
 		Aliases: []string{"functions", "func", "fn"},
 	}
 

--- a/pkg/riff/commands/function_create.go
+++ b/pkg/riff/commands/function_create.go
@@ -255,12 +255,13 @@ The riff.toml file takes the form:
 			fmt.Sprintf("%s function create my-func %s registry.example.com/image %s https://example.com/my-func.git", c.Name, cli.ImageFlagName, cli.GitRepoFlagName),
 			fmt.Sprintf("%s function create my-func %s registry.example.com/image %s ./my-func", c.Name, cli.ImageFlagName, cli.LocalPathFlagName),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NameArg(&opts.Name),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NameArg(&opts.Name),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 	cmd.Flags().StringVar(&opts.Image, cli.StripDash(cli.ImageFlagName), "_", "`repository` where the built images are pushed")

--- a/pkg/riff/commands/function_delete.go
+++ b/pkg/riff/commands/function_delete.go
@@ -82,12 +82,13 @@ automatically be discovered by the handler or processor.
 			fmt.Sprintf("%s function delete my-function", c.Name),
 			fmt.Sprintf("%s function delete %s ", c.Name, cli.AllFlagName),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NamesArg(&opts.Names),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NamesArg(&opts.Names),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 	cmd.Flags().BoolVar(&opts.All, cli.StripDash(cli.AllFlagName), false, "delete all functions within the namespace")

--- a/pkg/riff/commands/function_list.go
+++ b/pkg/riff/commands/function_list.go
@@ -90,7 +90,6 @@ For detail regarding the status of a single function, run:
 			fmt.Sprintf("%s function list", c.Name),
 			fmt.Sprintf("%s function list %s", c.Name, cli.AllNamespacesFlagName),
 		}, "\n"),
-		Args:    cli.Args(),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}

--- a/pkg/riff/commands/function_status.go
+++ b/pkg/riff/commands/function_status.go
@@ -78,12 +78,13 @@ function is processed or a build is in progress.
 		Example: strings.Join([]string{
 			fmt.Sprintf("%s function status my-function", c.Name),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NameArg(&opts.Name),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NameArg(&opts.Name),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 

--- a/pkg/riff/commands/function_tail.go
+++ b/pkg/riff/commands/function_tail.go
@@ -81,12 +81,13 @@ As new builds are started, the logs are displayed. To show historical logs use
 			fmt.Sprintf("%s function tail my-function", c.Name),
 			fmt.Sprintf("%s function tail my-function %s 1h", c.Name, cli.SinceFlagName),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NameArg(&opts.Name),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NameArg(&opts.Name),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 	cmd.Flags().StringVar(&opts.Since, cli.StripDash(cli.SinceFlagName), "", "time `duration` to start reading logs from")

--- a/pkg/riff/commands/handler.go
+++ b/pkg/riff/commands/handler.go
@@ -45,7 +45,6 @@ images and only update the handler image once those checks pass.
 
 The hostname to access the handler is available in the handler listing.
 `),
-		Args:    cli.Args(),
 		Aliases: []string{"handlers"},
 	}
 

--- a/pkg/riff/commands/handler_create.go
+++ b/pkg/riff/commands/handler_create.go
@@ -212,12 +212,13 @@ and ` + cli.EnvFromFlagName + ` to map values from a ConfigMap or Secret.
 			fmt.Sprintf("%s handler create my-func-handler %s my-func", c.Name, cli.FunctionRefFlagName),
 			fmt.Sprintf("%s handler create my-image-handler %s registry.example.com/my-image:latest", c.Name, cli.ImageFlagName),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NameArg(&opts.Name),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NameArg(&opts.Name),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 	cmd.Flags().StringVar(&opts.Image, cli.StripDash(cli.ImageFlagName), "", "container `image` to deploy")

--- a/pkg/riff/commands/handler_delete.go
+++ b/pkg/riff/commands/handler_delete.go
@@ -81,12 +81,13 @@ handler.
 			fmt.Sprintf("%s handler delete my-handler", c.Name),
 			fmt.Sprintf("%s handler delete %s ", c.Name, cli.AllFlagName),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NamesArg(&opts.Names),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NamesArg(&opts.Names),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 	cmd.Flags().BoolVar(&opts.All, cli.StripDash(cli.AllFlagName), false, "delete all handlers within the namespace")

--- a/pkg/riff/commands/handler_invoke.go
+++ b/pkg/riff/commands/handler_invoke.go
@@ -96,28 +96,29 @@ This command is not supported and may be removed in the future.
 `),
 		Example: strings.Join([]string{
 			fmt.Sprintf("%s handler invoke my-handler", c.Name),
-			fmt.Sprintf("%s handler invoke my-handler --text -- -d 'hello' -w '\n'", c.Name),
+			fmt.Sprintf("%s handler invoke my-handler --text -- -d 'hello' -w '\\n'", c.Name),
 			fmt.Sprintf("%s handler invoke my-handler /request/path", c.Name),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NameArg(&opts.Name),
-			cli.Arg{
-				Name:     "path",
-				Arity:    1,
-				Optional: true,
-				Set: func(cmd *cobra.Command, args []string, offset int) error {
-					if offset >= cmd.ArgsLenAtDash() && cmd.ArgsLenAtDash() != -1 {
-						return cli.ErrIgnoreArg
-					}
-					opts.Path = args[offset]
-					return nil
-				},
-			},
-			cli.BareDoubleDashArgs(&opts.BareArgs),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NameArg(&opts.Name),
+		cli.Arg{
+			Name:     "path",
+			Arity:    1,
+			Optional: true,
+			Set: func(cmd *cobra.Command, args []string, offset int) error {
+				if offset >= cmd.ArgsLenAtDash() && cmd.ArgsLenAtDash() != -1 {
+					return cli.ErrIgnoreArg
+				}
+				opts.Path = args[offset]
+				return nil
+			},
+		},
+		cli.BareDoubleDashArgs(&opts.BareArgs),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 	cmd.Flags().BoolVar(&opts.ContentTypeJSON, cli.StripDash(cli.JSONFlagName), false, "set the content type to application/json")

--- a/pkg/riff/commands/handler_list.go
+++ b/pkg/riff/commands/handler_list.go
@@ -90,7 +90,6 @@ For detail regarding the status of a single handler, run:
 			fmt.Sprintf("%s handler list", c.Name),
 			fmt.Sprintf("%s handler list %s", c.Name, cli.AllNamespacesFlagName),
 		}, "\n"),
-		Args:    cli.Args(),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}

--- a/pkg/riff/commands/handler_status.go
+++ b/pkg/riff/commands/handler_status.go
@@ -78,12 +78,13 @@ handler is processed.
 		Example: strings.Join([]string{
 			fmt.Sprintf("%s handler status my-handler", c.Name),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NameArg(&opts.Name),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NameArg(&opts.Name),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 

--- a/pkg/riff/commands/handler_tail.go
+++ b/pkg/riff/commands/handler_tail.go
@@ -82,12 +82,13 @@ As new handler instances are started, the logs are displayed. To show historical
 			fmt.Sprintf("%s handler tail my-handler", c.Name),
 			fmt.Sprintf("%s handler tail my-handler %s 1h", c.Name, cli.SinceFlagName),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NameArg(&opts.Name),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NameArg(&opts.Name),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 	cmd.Flags().StringVar(&opts.Since, cli.StripDash(cli.SinceFlagName), "", "time `duration` to start reading logs from")

--- a/pkg/riff/commands/processor.go
+++ b/pkg/riff/commands/processor.go
@@ -31,7 +31,6 @@ func NewProcessorCommand(ctx context.Context, c *cli.Config) *cobra.Command {
 		Long: strings.TrimSpace(`
 <todo>
 `),
-		Args:    cli.Args(),
 		Aliases: []string{"processors"},
 	}
 

--- a/pkg/riff/commands/processor_create.go
+++ b/pkg/riff/commands/processor_create.go
@@ -141,12 +141,13 @@ func NewProcessorCreateCommand(ctx context.Context, c *cli.Config) *cobra.Comman
 			fmt.Sprintf("%s processor create my-processor %s my-func %s my-input-stream", c.Name, cli.FunctionRefFlagName, cli.InputFlagName),
 			fmt.Sprintf("%s processor create my-processor %s my-func %s my-input-stream %s my-join-stream %s my-output-stream", c.Name, cli.FunctionRefFlagName, cli.InputFlagName, cli.InputFlagName, cli.OutputFlagName),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NameArg(&opts.Name),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NameArg(&opts.Name),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 	cmd.Flags().StringVar(&opts.FunctionRef, cli.StripDash(cli.FunctionRefFlagName), "", "`name` of function build to deploy")

--- a/pkg/riff/commands/processor_delete.go
+++ b/pkg/riff/commands/processor_delete.go
@@ -80,12 +80,13 @@ to the output streams. The streams and messages in each stream are preserved.
 			fmt.Sprintf("%s processor delete my-processor", c.Name),
 			fmt.Sprintf("%s processor delete %s ", c.Name, cli.AllFlagName),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NamesArg(&opts.Names),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NamesArg(&opts.Names),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 	cmd.Flags().BoolVar(&opts.All, cli.StripDash(cli.AllFlagName), false, "delete all processors within the namespace")

--- a/pkg/riff/commands/processor_list.go
+++ b/pkg/riff/commands/processor_list.go
@@ -90,7 +90,6 @@ For detail regarding the status of a single processor, run:
 			fmt.Sprintf("%s processor list", c.Name),
 			fmt.Sprintf("%s processor list %s", c.Name, cli.AllNamespacesFlagName),
 		}, "\n"),
-		Args:    cli.Args(),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}

--- a/pkg/riff/commands/processor_status.go
+++ b/pkg/riff/commands/processor_status.go
@@ -78,12 +78,13 @@ processor is processed.
 		Example: strings.Join([]string{
 			fmt.Sprintf("%s processor status my-processor", c.Name),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NameArg(&opts.Name),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NameArg(&opts.Name),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 

--- a/pkg/riff/commands/processor_tail.go
+++ b/pkg/riff/commands/processor_tail.go
@@ -82,12 +82,13 @@ As new processor instances are started, the logs are displayed. To show historic
 			fmt.Sprintf("%s processor tail my-processor", c.Name),
 			fmt.Sprintf("%s processor tail my-processor %s 1h", c.Name, cli.SinceFlagName),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NameArg(&opts.Name),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NameArg(&opts.Name),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 	cmd.Flags().StringVar(&opts.Since, cli.StripDash(cli.SinceFlagName), "", "time `duration` to start reading logs from")

--- a/pkg/riff/commands/riff.go
+++ b/pkg/riff/commands/riff.go
@@ -47,7 +47,6 @@ function or container image.
 Streams - the stream and processor commands to define streams of messages and
 map those streams to function inputs and outputs with processors.
 `),
-		Args: cli.Args(),
 	}
 
 	cmd.AddCommand(NewCredentialCommand(ctx, c))

--- a/pkg/riff/commands/root.go
+++ b/pkg/riff/commands/root.go
@@ -19,6 +19,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/projectriff/cli/pkg/cli"
@@ -47,6 +48,18 @@ func NewRootCommand(ctx context.Context, c *cli.Config) *cobra.Command {
 	cmd.AddCommand(NewCompletionCommand(ctx, c))
 	cmd.AddCommand(NewDocsCommand(ctx, c))
 	cmd.AddCommand(NewDoctorCommand(ctx, c))
+
+	// override usage template to add arguments
+	cmd.SetUsageTemplate(strings.ReplaceAll(cmd.UsageTemplate(), "{{.UseLine}}", "{{useLine .}}"))
+	cobra.AddTemplateFunc("useLine", func(cmd *cobra.Command) string {
+		result := cmd.UseLine()
+		flags := ""
+		if strings.HasSuffix(result, " [flags]") {
+			flags = " [flags]"
+			result = result[0 : len(result)-len(flags)]
+		}
+		return result + cli.FormatArgs(cmd) + flags
+	})
 
 	return cmd
 }

--- a/pkg/riff/commands/root_test.go
+++ b/pkg/riff/commands/root_test.go
@@ -17,6 +17,7 @@
 package commands_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/projectriff/cli/pkg/riff/commands"
@@ -28,6 +29,24 @@ func TestRootCommand(t *testing.T) {
 		{
 			Name: "empty",
 			Args: []string{},
+		},
+		{
+			Name: "help",
+			Args: []string{"--help"},
+			Verify: func(t *testing.T, output string, err error) {
+				if !strings.Contains(output, "riff [command]") {
+					t.Errorf("expected help to contain command without args")
+				}
+			},
+		},
+		{
+			Name: "help subcommand with args",
+			Args: []string{"function", "create", "--help"},
+			Verify: func(t *testing.T, output string, err error) {
+				if !strings.Contains(output, "riff function create <name> [flags]") {
+					t.Errorf("expected help to contain command with args")
+				}
+			},
 		},
 	}
 

--- a/pkg/riff/commands/stream.go
+++ b/pkg/riff/commands/stream.go
@@ -31,7 +31,6 @@ func NewStreamCommand(ctx context.Context, c *cli.Config) *cobra.Command {
 		Long: strings.TrimSpace(`
 <todo>
 `),
-		Args:    cli.Args(),
 		Aliases: []string{"streams"},
 	}
 

--- a/pkg/riff/commands/stream_create.go
+++ b/pkg/riff/commands/stream_create.go
@@ -99,12 +99,13 @@ func NewStreamCreateCommand(ctx context.Context, c *cli.Config) *cobra.Command {
 <todo>
 `),
 		Example: fmt.Sprintf("%s stream create %s my-provider", c.Name, cli.ProviderFlagName),
-		Args: cli.Args(
-			cli.NameArg(&opts.Name),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NameArg(&opts.Name),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 	cmd.Flags().StringVar(&opts.Provider, cli.StripDash(cli.ProviderFlagName), "", "`name` of stream provider")

--- a/pkg/riff/commands/stream_delete.go
+++ b/pkg/riff/commands/stream_delete.go
@@ -81,12 +81,13 @@ messaging middleware, depending on the implementation.
 			fmt.Sprintf("%s stream delete my-stream", c.Name),
 			fmt.Sprintf("%s stream delete %s ", c.Name, cli.AllFlagName),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NamesArg(&opts.Names),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NamesArg(&opts.Names),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 	cmd.Flags().BoolVar(&opts.All, cli.StripDash(cli.AllFlagName), false, "delete all streams within the namespace")

--- a/pkg/riff/commands/stream_list.go
+++ b/pkg/riff/commands/stream_list.go
@@ -90,7 +90,6 @@ For detail regarding the status of a single stream, run:
 			fmt.Sprintf("%s stream list", c.Name),
 			fmt.Sprintf("%s stream list %s", c.Name, cli.AllNamespacesFlagName),
 		}, "\n"),
-		Args:    cli.Args(),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}

--- a/pkg/riff/commands/stream_status.go
+++ b/pkg/riff/commands/stream_status.go
@@ -78,12 +78,13 @@ stream is being processed.
 		Example: strings.Join([]string{
 			fmt.Sprintf("%s stream status my-stream", c.Name),
 		}, "\n"),
-		Args: cli.Args(
-			cli.NameArg(&opts.Name),
-		),
 		PreRunE: cli.ValidateOptions(ctx, opts),
 		RunE:    cli.ExecOptions(ctx, c, opts),
 	}
+
+	cli.Args(cmd,
+		cli.NameArg(&opts.Name),
+	)
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
 


### PR DESCRIPTION
Add each argument's name and optionality in the usage line for the
command's help (both command line and markdown).

The args add metadata to the command as annotations. That metadata is
reversed to create a formated arguments string when rendering the help.

The markdown docs do not allow for custom rendering of the body.
Instead, we can hack the command usage to add the arg formated string
and append it to the usage. This only works because the commands have
already been added to their parent command. As it's a hack, it may stop
working any time we update cobra. The tests will fail if/when this hack
no longer works.