### PR TITLE
Restore windows tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,12 +62,11 @@ jobs:
         qualifier: minikube
         cluster: minikube
         registry: dockerhub
-      # TODO restore windows support once we have a linux docker daemon available
-      # windows:
-      #   imageName: windows-2019
-      #   qualifier: windows
-      #   cluster: gke
-      #   registry: gcr
+      windows:
+        imageName: windows-2019
+        qualifier: windows
+        cluster: gke
+        registry: gcr
   pool:
     vmImage: $(imageName)
   variables:

--- a/ci/fats.sh
+++ b/ci/fats.sh
@@ -4,8 +4,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-version=`cat VERSION`
-commit=$(git rev-parse HEAD)
+readonly version=$(cat VERSION)
+readonly git_sha=$(git rev-parse HEAD)
+readonly git_timestamp=$(TZ=UTC git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")
+readonly slug=${version}-${git_timestamp}-${git_sha:0:16}
 
 # fetch FATS scripts
 fats_dir=`dirname "${BASH_SOURCE[0]}"`/fats
@@ -14,15 +16,14 @@ fats_refspec=1a462b4a35ebdb66d678d648b5803fa498871ec6 # projectriff/fats master 
 source `dirname "${BASH_SOURCE[0]}"`/fats-fetch.sh $fats_dir $fats_refspec $fats_repo
 source $fats_dir/.util.sh
 
-
 # install riff-cli
 echo "Installing riff"
 if [ "$machine" == "MinGw" ]; then
-  curl https://storage.googleapis.com/projectriff/riff-cli/releases/builds/v${version}-${commit}/riff-windows-amd64.zip > riff.zip
+  curl https://storage.googleapis.com/projectriff/riff-cli/releases/builds/v${slug}/riff-windows-amd64.zip > riff.zip
   unzip riff.zip -d /usr/bin/
   rm riff.zip
 else
-  curl https://storage.googleapis.com/projectriff/riff-cli/releases/builds/v${version}-${commit}/riff-linux-amd64.tgz | tar xz
+  curl https://storage.googleapis.com/projectriff/riff-cli/releases/builds/v${slug}/riff-linux-amd64.tgz | tar xz
   chmod +x riff
   sudo cp riff /usr/bin/riff
 fi

--- a/ci/fats.sh
+++ b/ci/fats.sh
@@ -12,7 +12,7 @@ readonly slug=${version}-${git_timestamp}-${git_sha:0:16}
 # fetch FATS scripts
 fats_dir=`dirname "${BASH_SOURCE[0]}"`/fats
 fats_repo="projectriff/fats"
-fats_refspec=1a462b4a35ebdb66d678d648b5803fa498871ec6 # projectriff/fats master as of 2019-07-09
+fats_refspec=caa8e5e519d9a0f64fbb73609b66ccdd7d11846e # projectriff/fats master as of 2019-07-19
 source `dirname "${BASH_SOURCE[0]}"`/fats-fetch.sh $fats_dir $fats_refspec $fats_repo
 source $fats_dir/.util.sh
 


### PR DESCRIPTION
We no longer need a local docker daemon to install riff.