### PR TITLE
Disable local-path builds from Windows

### DIFF
--- a/pkg/riff/commands/application_create.go
+++ b/pkg/riff/commands/application_create.go
@@ -19,6 +19,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 	"time"
 
@@ -104,6 +105,10 @@ func (opts *ApplicationCreateOptions) Validate(ctx context.Context) *cli.FieldEr
 
 	if opts.DryRun && opts.Tail {
 		errs = errs.Also(cli.ErrMultipleOneOf(cli.DryRunFlagName, cli.TailFlagName))
+	}
+
+	if opts.LocalPath != "" && runtime.GOOS == "windows" {
+		errs = errs.Also(cli.ErrInvalidValue(fmt.Sprintf("%s is not available on Windows", cli.LocalPathFlagName), cli.LocalPathFlagName))
 	}
 
 	return errs

--- a/pkg/riff/commands/function_create.go
+++ b/pkg/riff/commands/function_create.go
@@ -19,6 +19,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 	"time"
 
@@ -110,6 +111,10 @@ func (opts *FunctionCreateOptions) Validate(ctx context.Context) *cli.FieldError
 
 	if opts.DryRun && opts.Tail {
 		errs = errs.Also(cli.ErrMultipleOneOf(cli.DryRunFlagName, cli.TailFlagName))
+	}
+
+	if opts.LocalPath != "" && runtime.GOOS == "windows" {
+		errs = errs.Also(cli.ErrInvalidValue(fmt.Sprintf("%s is not available on Windows", cli.LocalPathFlagName), cli.LocalPathFlagName))
 	}
 
 	return errs

--- a/pkg/riff/commands/function_create_test.go
+++ b/pkg/riff/commands/function_create_test.go
@@ -19,6 +19,8 @@ package commands_test
 import (
 	"context"
 	"fmt"
+	goruntime "runtime"
+	"strings"
 	"testing"
 
 	"github.com/buildpack/pack"
@@ -209,6 +211,19 @@ func TestFunctionCreateOptions(t *testing.T) {
 			},
 			ExpectFieldError: cli.ErrMultipleOneOf(cli.DryRunFlagName, cli.TailFlagName),
 		},
+	}
+
+	if goruntime.GOOS == "windows" {
+		for i, tr := range table {
+			opts, _ := tr.Options.(*commands.FunctionCreateOptions)
+			if opts.LocalPath != "" {
+				tr.ShouldValidate = false
+				tr.ExpectFieldError = tr.ExpectFieldError.Also(
+					cli.ErrInvalidValue(fmt.Sprintf("%s is not available on Windows", cli.LocalPathFlagName), cli.LocalPathFlagName),
+				)
+			}
+			table[i] = tr
+		}
 	}
 
 	table.Run(t)
@@ -878,6 +893,15 @@ To continue watching logs run: riff function tail my-function --namespace defaul
 			},
 			ShouldError: true,
 		},
+	}
+
+	if goruntime.GOOS == "windows" {
+		for i, tr := range table {
+			if strings.Contains(strings.Join(tr.Args, "|"), cli.LocalPathFlagName) {
+				tr.Skip = true
+				table[i] = tr
+			}
+		}
 	}
 
 	table.Run(t, commands.NewFunctionCreateCommand)


### PR DESCRIPTION
We can't make builds from Window's sources reliable because of the file
permission missmatch with the linux system in the Docker container.
Windows execute permissions are granted based on the file extension
while Linux execute permissions are explicitly granted.

The best way for Windows users to build a container from source is to
commit the local source into a git repository. Git has special handling
to preserve the file permissions when checked out on a linux system.

As it stands, builds that don't require executing any of the source
files will work, while all other builds will fail. The inoperable builds
often fail in subtile and confusing ways. Worse, it's quite possible for
the build to pass and later fail at runtime when a new binary is invoked
for the first time.

Because we can't have confidence in local builds from Windows, we are
removing the capability.