### PR TITLE
Add kpack annotations to credentials

### DIFF
--- a/pkg/build/commands/credential_apply.go
+++ b/pkg/build/commands/credential_apply.go
@@ -215,6 +215,7 @@ func makeCredential(opts *CredentialApplyOptions) (*corev1.Secret, string, error
 		}
 		secret.Annotations = map[string]string{
 			"build.knative.dev/docker-0": "https://index.docker.io/v1/",
+			"build.pivotal.io/docker":    "https://index.docker.io/v1/",
 		}
 		secret.Type = corev1.SecretTypeBasicAuth
 		secret.StringData = map[string]string{
@@ -236,6 +237,7 @@ func makeCredential(opts *CredentialApplyOptions) (*corev1.Secret, string, error
 			"build.knative.dev/docker-1": "https://us.gcr.io",
 			"build.knative.dev/docker-2": "https://eu.gcr.io",
 			"build.knative.dev/docker-3": "https://asia.gcr.io",
+			"build.pivotal.io/docker":    "https://gcr.io",
 		}
 		secret.Type = corev1.SecretTypeBasicAuth
 		secret.StringData = map[string]string{
@@ -255,6 +257,7 @@ func makeCredential(opts *CredentialApplyOptions) (*corev1.Secret, string, error
 		}
 		secret.Annotations = map[string]string{
 			"build.knative.dev/docker-0": opts.Registry,
+			"build.pivotal.io/docker":    opts.Registry,
 		}
 		secret.Type = corev1.SecretTypeBasicAuth
 		secret.StringData = map[string]string{

--- a/pkg/build/commands/credential_apply_test.go
+++ b/pkg/build/commands/credential_apply_test.go
@@ -190,6 +190,7 @@ func TestCredentialApplyCommand(t *testing.T) {
 						Labels:    map[string]string{credentialLabel: "docker-hub"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
+							"build.pivotal.io/docker":    "https://index.docker.io/v1/",
 						},
 					},
 					Type: corev1.SecretTypeBasicAuth,
@@ -217,6 +218,7 @@ Apply credentials "test-credential"
 							"build.knative.dev/docker-1": "https://us.gcr.io",
 							"build.knative.dev/docker-2": "https://eu.gcr.io",
 							"build.knative.dev/docker-3": "https://asia.gcr.io",
+							"build.pivotal.io/docker":    "https://gcr.io",
 						},
 					},
 					Type: corev1.SecretTypeBasicAuth,
@@ -252,6 +254,7 @@ Apply credentials "test-credential"
 						Labels:    map[string]string{credentialLabel: "basic-auth"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": registryURL,
+							"build.pivotal.io/docker":    registryURL,
 						},
 					},
 					Type: corev1.SecretTypeBasicAuth,
@@ -276,7 +279,8 @@ Apply credentials "test-credential"
 						Namespace: defaultNamespace,
 						Labels:    map[string]string{credentialLabel: "docker-hub"},
 						Annotations: map[string]string{
-							"build.knative.dev/docker-0": "https://index.dockerhub.io/projectriff",
+							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
+							"build.pivotal.io/docker":    "https://index.docker.io/v1/",
 						},
 					},
 					Type: corev1.SecretTypeBasicAuth,
@@ -294,6 +298,7 @@ Apply credentials "test-credential"
 						Labels:    map[string]string{credentialLabel: "basic-auth"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": registryURL,
+							"build.pivotal.io/docker":    registryURL,
 						},
 					},
 					Type: corev1.SecretTypeBasicAuth,
@@ -318,7 +323,8 @@ Apply credentials "test-credential"
 						Namespace: defaultNamespace,
 						Labels:    map[string]string{credentialLabel: "docker-hub"},
 						Annotations: map[string]string{
-							"build.knative.dev/docker-0": "https://index.dockerhub.io/projectriff",
+							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
+							"build.pivotal.io/docker":    "https://index.docker.io/v1/",
 						},
 					},
 					Type: corev1.SecretTypeBasicAuth,
@@ -348,6 +354,7 @@ Apply credentials "test-credential"
 						Labels:    map[string]string{credentialLabel: "basic-auth"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": registryURL,
+							"build.pivotal.io/docker":    registryURL,
 						},
 					},
 					Type: corev1.SecretTypeBasicAuth,
@@ -370,7 +377,8 @@ Apply credentials "test-credential"
 						Namespace: defaultNamespace,
 						Labels:    map[string]string{credentialLabel: "docker-hub"},
 						Annotations: map[string]string{
-							"build.knative.dev/docker-0": "https://index.dockerhub.io/projectriff",
+							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
+							"build.pivotal.io/docker":    "https://index.docker.io/v1/",
 						},
 					},
 					Type: corev1.SecretTypeBasicAuth,
@@ -391,6 +399,7 @@ Apply credentials "test-credential"
 						Labels:    map[string]string{credentialLabel: "basic-auth"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": registryURL,
+							"build.pivotal.io/docker":    registryURL,
 						},
 					},
 					Type: corev1.SecretTypeBasicAuth,
@@ -429,6 +438,7 @@ Apply credentials "test-credential"
 						Labels:    map[string]string{credentialLabel: "docker-hub"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
+							"build.pivotal.io/docker":    "https://index.docker.io/v1/",
 						},
 					},
 					Type: corev1.SecretTypeBasicAuth,
@@ -466,6 +476,7 @@ Set default image prefix to "docker.io/projectriff"
 							"build.knative.dev/docker-1": "https://us.gcr.io",
 							"build.knative.dev/docker-2": "https://eu.gcr.io",
 							"build.knative.dev/docker-3": "https://asia.gcr.io",
+							"build.pivotal.io/docker":    "https://gcr.io",
 						},
 					},
 					Type: corev1.SecretTypeBasicAuth,
@@ -501,6 +512,7 @@ Set default image prefix to "gcr.io/my-gcp-project"
 						Labels:    map[string]string{credentialLabel: "basic-auth"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": registryURL,
+							"build.pivotal.io/docker":    registryURL,
 						},
 					},
 					Type: corev1.SecretTypeBasicAuth,
@@ -554,6 +566,7 @@ Set default image prefix to "example.com"
 						Labels:    map[string]string{credentialLabel: "docker-hub"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
+							"build.pivotal.io/docker":    "https://index.docker.io/v1/",
 						},
 					},
 					Type: corev1.SecretTypeBasicAuth,
@@ -595,6 +608,7 @@ Set default image prefix to "docker.io/projectriff"
 						Labels:    map[string]string{credentialLabel: "docker-hub"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
+							"build.pivotal.io/docker":    "https://index.docker.io/v1/",
 						},
 					},
 					Type: corev1.SecretTypeBasicAuth,
@@ -621,6 +635,7 @@ Set default image prefix to "docker.io/projectriff"
 						Labels:    map[string]string{credentialLabel: "docker-hub"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
+							"build.pivotal.io/docker":    "https://index.docker.io/v1/",
 						},
 					},
 					Type: corev1.SecretTypeBasicAuth,
@@ -668,6 +683,7 @@ Set default image prefix to "docker.io/projectriff"
 						Labels:    map[string]string{credentialLabel: "docker-hub"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
+							"build.pivotal.io/docker":    "https://index.docker.io/v1/",
 						},
 					},
 					Type: corev1.SecretTypeBasicAuth,
@@ -702,6 +718,7 @@ kind: Secret
 metadata:
   annotations:
     build.knative.dev/docker-0: https://index.docker.io/v1/
+    build.pivotal.io/docker: https://index.docker.io/v1/
   creationTimestamp: null
   labels:
     build.projectriff.io/credential: docker-hub
@@ -753,6 +770,7 @@ kind: Secret
 metadata:
   annotations:
     build.knative.dev/docker-0: https://index.docker.io/v1/
+    build.pivotal.io/docker: https://index.docker.io/v1/
   creationTimestamp: null
   labels:
     build.projectriff.io/credential: docker-hub

--- a/pkg/build/commands/credential_list.go
+++ b/pkg/build/commands/credential_list.go
@@ -118,7 +118,7 @@ func (opts *CredentialListOptions) print(credential *corev1.Secret, _ printers.P
 	row.Cells = append(row.Cells,
 		credential.Name,
 		credential.Labels[build.CredentialLabelKey],
-		credential.Annotations["build.knative.dev/docker-0"],
+		credential.Annotations["build.pivotal.io/docker"],
 		cli.FormatTimestampSince(credential.CreationTimestamp, now),
 	)
 	return []metav1beta1.TableRow{row}, nil

--- a/pkg/build/commands/credential_list_test.go
+++ b/pkg/build/commands/credential_list_test.go
@@ -81,10 +81,13 @@ No credentials found.
 			GivenObjects: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        credentialName,
-						Namespace:   defaultNamespace,
-						Labels:      map[string]string{credentialLabel: "docker-hub"},
-						Annotations: map[string]string{"build.knative.dev/docker-0": "https://index.docker.io/v1/"},
+						Name:      credentialName,
+						Namespace: defaultNamespace,
+						Labels:    map[string]string{credentialLabel: "docker-hub"},
+						Annotations: map[string]string{
+							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
+							"build.pivotal.io/docker":    "https://index.docker.io/v1/",
+						},
 					},
 				},
 			},
@@ -99,10 +102,13 @@ test-credential   docker-hub   https://index.docker.io/v1/   <unknown>
 			GivenObjects: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        credentialName,
-						Namespace:   defaultNamespace,
-						Labels:      map[string]string{credentialLabel: "docker-hub"},
-						Annotations: map[string]string{"build.knative.dev/docker-0": "https://index.docker.io/v1/"},
+						Name:      credentialName,
+						Namespace: defaultNamespace,
+						Labels:    map[string]string{credentialLabel: "docker-hub"},
+						Annotations: map[string]string{
+							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
+							"build.pivotal.io/docker":    "https://index.docker.io/v1/",
+						},
 					},
 				},
 			},
@@ -116,26 +122,35 @@ No credentials found.
 			GivenObjects: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        "registry",
-						Namespace:   defaultNamespace,
-						Labels:      map[string]string{credentialLabel: "basic-auth"},
-						Annotations: map[string]string{"build.knative.dev/docker-0": "https://registry.example.com/"},
+						Name:      "registry",
+						Namespace: defaultNamespace,
+						Labels:    map[string]string{credentialLabel: "basic-auth"},
+						Annotations: map[string]string{
+							"build.knative.dev/docker-0": "https://registry.example.com/",
+							"build.pivotal.io/docker":    "https://registry.example.com/",
+						},
 					},
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        "docker-hub",
-						Namespace:   defaultNamespace,
-						Labels:      map[string]string{credentialLabel: "docker-hub"},
-						Annotations: map[string]string{"build.knative.dev/docker-0": "https://index.docker.io/v1/"},
+						Name:      "docker-hub",
+						Namespace: defaultNamespace,
+						Labels:    map[string]string{credentialLabel: "docker-hub"},
+						Annotations: map[string]string{
+							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
+							"build.pivotal.io/docker":    "https://index.docker.io/v1/",
+						},
 					},
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        "gcr",
-						Namespace:   defaultNamespace,
-						Labels:      map[string]string{credentialLabel: "gcr"},
-						Annotations: map[string]string{"build.knative.dev/docker-0": "https://gcr.io"},
+						Name:      "gcr",
+						Namespace: defaultNamespace,
+						Labels:    map[string]string{credentialLabel: "gcr"},
+						Annotations: map[string]string{
+							"build.knative.dev/docker-0": "https://gcr.io",
+							"build.pivotal.io/docker":    "https://gcr.io",
+						},
 					},
 				},
 			},
@@ -152,18 +167,24 @@ registry     basic-auth   https://registry.example.com/   <unknown>
 			GivenObjects: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        credentialName,
-						Namespace:   defaultNamespace,
-						Labels:      map[string]string{credentialLabel: "docker-hub"},
-						Annotations: map[string]string{"build.knative.dev/docker-0": "https://index.docker.io/v1/"},
+						Name:      credentialName,
+						Namespace: defaultNamespace,
+						Labels:    map[string]string{credentialLabel: "docker-hub"},
+						Annotations: map[string]string{
+							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
+							"build.pivotal.io/docker":    "https://index.docker.io/v1/",
+						},
 					},
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        credentialOtherName,
-						Namespace:   otherNamespace,
-						Labels:      map[string]string{credentialLabel: "docker-hub"},
-						Annotations: map[string]string{"build.knative.dev/docker-0": "https://index.docker.io/v1/"},
+						Name:      credentialOtherName,
+						Namespace: otherNamespace,
+						Labels:    map[string]string{credentialLabel: "docker-hub"},
+						Annotations: map[string]string{
+							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
+							"build.pivotal.io/docker":    "https://index.docker.io/v1/",
+						},
 					},
 				},
 			},


### PR DESCRIPTION
kpack uses a similar annotation as Knative Build to match secrets to
image registries. The Knative Build annotations should be viewed as
deprecated, however, we will support both annotations until we have
fully transitions to kpack.