### PR TITLE
Log when a resource is ready

### DIFF
--- a/pkg/build/commands/application_create.go
+++ b/pkg/build/commands/application_create.go
@@ -198,6 +198,7 @@ func (opts *ApplicationCreateOptions) Exec(ctx context.Context, c *cli.Config) e
 		if err != nil {
 			return err
 		}
+		c.Successf("Application %q is ready\n", application.Name)
 	}
 	return nil
 }

--- a/pkg/build/commands/application_create_test.go
+++ b/pkg/build/commands/application_create_test.go
@@ -730,6 +730,7 @@ Created application "my-application"
 			ExpectOutput: `
 Created application "my-application"
 ...log output...
+Application "my-application" is ready
 `,
 		},
 		{

--- a/pkg/build/commands/container_create.go
+++ b/pkg/build/commands/container_create.go
@@ -109,6 +109,7 @@ func (opts *ContainerCreateOptions) Exec(ctx context.Context, c *cli.Config) err
 		if err != nil {
 			return err
 		}
+		c.Successf("Container %q is ready\n", container.Name)
 	}
 	return nil
 }

--- a/pkg/build/commands/container_create_test.go
+++ b/pkg/build/commands/container_create_test.go
@@ -243,6 +243,7 @@ Created container "my-container"
 			ExpectOutput: `
 Created container "my-container"
 ...log output...
+Container "my-container" is ready
 `,
 		},
 		{

--- a/pkg/build/commands/function_create.go
+++ b/pkg/build/commands/function_create.go
@@ -214,6 +214,7 @@ func (opts *FunctionCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 		if err != nil {
 			return err
 		}
+		c.Successf("Function %q is ready\n", function.Name)
 	}
 	return nil
 }

--- a/pkg/build/commands/function_create_test.go
+++ b/pkg/build/commands/function_create_test.go
@@ -766,6 +766,7 @@ Created function "my-function"
 			ExpectOutput: `
 Created function "my-function"
 ...log output...
+Function "my-function" is ready
 `,
 		},
 		{

--- a/pkg/core/commands/deployer_create.go
+++ b/pkg/core/commands/deployer_create.go
@@ -188,6 +188,7 @@ func (opts *DeployerCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 		if err != nil {
 			return err
 		}
+		c.Successf("Deployer %q is ready\n", deployer.Name)
 	}
 	return nil
 }

--- a/pkg/core/commands/deployer_create_test.go
+++ b/pkg/core/commands/deployer_create_test.go
@@ -463,6 +463,7 @@ Created deployer "my-deployer"
 			ExpectOutput: `
 Created deployer "my-deployer"
 ...log output...
+Deployer "my-deployer" is ready
 `,
 		},
 		{

--- a/pkg/knative/commands/adapter_create.go
+++ b/pkg/knative/commands/adapter_create.go
@@ -184,6 +184,7 @@ func (opts *AdapterCreateOptions) Exec(ctx context.Context, c *cli.Config) error
 		if err != nil {
 			return err
 		}
+		c.Successf("Adapter %q is ready\n", adapter.Name)
 	}
 	return nil
 }

--- a/pkg/knative/commands/adapter_create_test.go
+++ b/pkg/knative/commands/adapter_create_test.go
@@ -407,6 +407,7 @@ Created adapter "my-adapter"
 			ExpectOutput: `
 Created adapter "my-adapter"
 ...log output...
+Adapter "my-adapter" is ready
 `,
 		},
 		{

--- a/pkg/knative/commands/deployer_create.go
+++ b/pkg/knative/commands/deployer_create.go
@@ -188,6 +188,7 @@ func (opts *DeployerCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 		if err != nil {
 			return err
 		}
+		c.Successf("Deployer %q is ready\n", deployer.Name)
 	}
 	return nil
 }

--- a/pkg/knative/commands/deployer_create_test.go
+++ b/pkg/knative/commands/deployer_create_test.go
@@ -463,6 +463,7 @@ Created deployer "my-deployer"
 			ExpectOutput: `
 Created deployer "my-deployer"
 ...log output...
+Deployer "my-deployer" is ready
 `,
 		},
 		{

--- a/pkg/streaming/commands/processor_create.go
+++ b/pkg/streaming/commands/processor_create.go
@@ -120,6 +120,7 @@ func (opts *ProcessorCreateOptions) Exec(ctx context.Context, c *cli.Config) err
 		if err != nil {
 			return err
 		}
+		c.Successf("Processor %q is ready\n", processor.Name)
 	}
 	return nil
 }

--- a/pkg/streaming/commands/processor_create_test.go
+++ b/pkg/streaming/commands/processor_create_test.go
@@ -331,6 +331,7 @@ Created processor "my-processor"
 			ExpectOutput: `
 Created processor "my-processor"
 ...log output...
+Processor "my-processor" is ready
 `,
 		},
 		{


### PR DESCRIPTION
When tailing logs after creating a resource. We now log that the
resource is ready when the resource becomes ready. Previously, we only
logged if the resource erred or the create timed out.

Fixes #85