### PR TITLE
Allow cpu and memory limits for deployers

### DIFF
--- a/docs/riff_core_deployer_create.md
+++ b/docs/riff_core_deployer_create.md
@@ -41,6 +41,8 @@ riff core deployer create my-image-deployer --image registry.example.com/my-imag
       --function-ref name       name of function to deploy
   -h, --help                    help for create
       --image image             container image to deploy
+      --limit-cpu cores         the maximum amount of cpu allowed, in CPU cores (500m = .5 cores)
+      --limit-memory bytes      the maximum amount of memory allowed, in bytes (500Mi = 500MiB = 500 * 1024 * 1024)
   -n, --namespace name          kubernetes namespace (defaulted from kube config)
       --tail                    watch deployer logs
       --wait-timeout duration   duration to wait for the deployer to become ready when watching logs (default "10m")

--- a/docs/riff_knative_deployer_create.md
+++ b/docs/riff_knative_deployer_create.md
@@ -41,6 +41,8 @@ riff knative deployer create my-image-deployer --image registry.example.com/my-i
       --function-ref name       name of function to deploy
   -h, --help                    help for create
       --image image             container image to deploy
+      --limit-cpu cores         the maximum amount of cpu allowed, in CPU cores (500m = .5 cores)
+      --limit-memory bytes      the maximum amount of memory allowed, in bytes (500Mi = 500MiB = 500 * 1024 * 1024)
   -n, --namespace name          kubernetes namespace (defaulted from kube config)
       --tail                    watch deployer logs
       --wait-timeout duration   duration to wait for the deployer to become ready when watching logs (default "10m")

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -48,6 +48,8 @@ const (
 	InputFlagName                 = "--input"
 	InvokerFlagName               = "--invoker"
 	KubeConfigFlagName            = "--kube-config"
+	LimitCPUFlagName              = "--limit-cpu"
+	LimitMemoryFlagName           = "--limit-memory"
 	LocalPathFlagName             = "--local-path"
 	NamespaceFlagName             = "--namespace"
 	NoColorFlagName               = "--no-color"

--- a/pkg/core/commands/deployer_create.go
+++ b/pkg/core/commands/deployer_create.go
@@ -31,6 +31,7 @@ import (
 	corev1alpha1 "github.com/projectriff/system/pkg/apis/core/v1alpha1"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -44,6 +45,9 @@ type DeployerCreateOptions struct {
 
 	Env     []string
 	EnvFrom []string
+
+	LimitCPU    string
+	LimitMemory string
 
 	Tail        bool
 	WaitTimeout string
@@ -98,6 +102,13 @@ func (opts *DeployerCreateOptions) Validate(ctx context.Context) cli.FieldErrors
 
 	errs = errs.Also(validation.EnvVars(opts.Env, cli.EnvFlagName))
 	errs = errs.Also(validation.EnvVarFroms(opts.EnvFrom, cli.EnvFromFlagName))
+
+	if opts.LimitCPU != "" {
+		errs = errs.Also(validation.Quantity(opts.LimitCPU, cli.LimitCPUFlagName))
+	}
+	if opts.LimitMemory != "" {
+		errs = errs.Also(validation.Quantity(opts.LimitMemory, cli.LimitMemoryFlagName))
+	}
 
 	if opts.Tail {
 		if opts.WaitTimeout == "" {
@@ -157,6 +168,18 @@ func (opts *DeployerCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 			deployer.Spec.Template.Containers[0].Env = []corev1.EnvVar{}
 		}
 		deployer.Spec.Template.Containers[0].Env = append(deployer.Spec.Template.Containers[0].Env, parsers.EnvVarFrom(env))
+	}
+
+	if (opts.LimitCPU != "" || opts.LimitMemory != "") && deployer.Spec.Template.Containers[0].Resources.Limits == nil {
+		deployer.Spec.Template.Containers[0].Resources.Limits = corev1.ResourceList{}
+	}
+	if opts.LimitCPU != "" {
+		// parse errors are handled by the opt validation
+		deployer.Spec.Template.Containers[0].Resources.Limits[corev1.ResourceCPU] = resource.MustParse(opts.LimitCPU)
+	}
+	if opts.LimitMemory != "" {
+		// parse errors are handled by the opt validation
+		deployer.Spec.Template.Containers[0].Resources.Limits[corev1.ResourceMemory] = resource.MustParse(opts.LimitMemory)
 	}
 
 	if opts.DryRun {
@@ -235,6 +258,8 @@ and ` + cli.EnvFromFlagName + ` to map values from a ConfigMap or Secret.
 	cmd.Flags().StringVar(&opts.FunctionRef, cli.StripDash(cli.FunctionRefFlagName), "", "`name` of function to deploy")
 	cmd.Flags().StringArrayVar(&opts.Env, cli.StripDash(cli.EnvFlagName), []string{}, fmt.Sprintf("environment `variable` defined as a key value pair separated by an equals sign, example %q (may be set multiple times)", fmt.Sprintf("%s MY_VAR=my-value", cli.EnvFlagName)))
 	cmd.Flags().StringArrayVar(&opts.EnvFrom, cli.StripDash(cli.EnvFromFlagName), []string{}, fmt.Sprintf("environment `variable` from a config map or secret, example %q, %q (may be set multiple times)", fmt.Sprintf("%s MY_SECRET_VALUE=secretKeyRef:my-secret-name:key-in-secret", cli.EnvFromFlagName), fmt.Sprintf("%s MY_CONFIG_MAP_VALUE=configMapKeyRef:my-config-map-name:key-in-config-map", cli.EnvFromFlagName)))
+	cmd.Flags().StringVar(&opts.LimitCPU, cli.StripDash(cli.LimitCPUFlagName), "", "the maximum amount of cpu allowed, in CPU `cores` (500m = .5 cores)")
+	cmd.Flags().StringVar(&opts.LimitMemory, cli.StripDash(cli.LimitMemoryFlagName), "", "the maximum amount of memory allowed, in `bytes` (500Mi = 500MiB = 500 * 1024 * 1024)")
 	cmd.Flags().BoolVar(&opts.Tail, cli.StripDash(cli.TailFlagName), false, "watch deployer logs")
 	cmd.Flags().StringVar(&opts.WaitTimeout, cli.StripDash(cli.WaitTimeoutFlagName), "10m", "`duration` to wait for the deployer to become ready when watching logs")
 	cmd.Flags().BoolVar(&opts.DryRun, cli.StripDash(cli.DryRunFlagName), false, "print kubernetes resources to stdout rather than apply them to the cluster, messages normally on stdout will be sent to stderr")

--- a/pkg/core/commands/deployer_create_test.go
+++ b/pkg/core/commands/deployer_create_test.go
@@ -29,6 +29,7 @@ import (
 	corev1alpha1 "github.com/projectriff/system/pkg/apis/core/v1alpha1"
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	cachetesting "k8s.io/client-go/tools/cache/testing"
@@ -132,6 +133,29 @@ func TestDeployerCreateOptions(t *testing.T) {
 				EnvFrom:         []string{"VAR1=someOtherKeyRef:name:key"},
 			},
 			ExpectFieldErrors: cli.ErrInvalidArrayValue("VAR1=someOtherKeyRef:name:key", cli.EnvFromFlagName, 0),
+		},
+		{
+			Name: "with limits",
+			Options: &commands.DeployerCreateOptions{
+				ResourceOptions: rifftesting.ValidResourceOptions,
+				Image:           "example.com/repo:tag",
+				LimitCPU:        "500m",
+				LimitMemory:     "512Mi",
+			},
+			ShouldValidate: true,
+		},
+		{
+			Name: "with invalid limits",
+			Options: &commands.DeployerCreateOptions{
+				ResourceOptions: rifftesting.ValidResourceOptions,
+				Image:           "example.com/repo:tag",
+				LimitCPU:        "50%",
+				LimitMemory:     "NaN",
+			},
+			ExpectFieldErrors: cli.FieldErrors{}.Also(
+				cli.ErrInvalidValue("50%", cli.LimitCPUFlagName),
+				cli.ErrInvalidValue("NaN", cli.LimitMemoryFlagName),
+			),
 		},
 		{
 			Name: "with tail",
@@ -351,6 +375,36 @@ Created deployer "my-deployer"
 													Key: "my-key",
 												},
 											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectOutput: `
+Created deployer "my-deployer"
+`,
+		},
+		{
+			Name: "create with limits",
+			Args: []string{deployerName, cli.ImageFlagName, image, cli.LimitCPUFlagName, "100m", cli.LimitMemoryFlagName, "128Mi"},
+			ExpectCreates: []runtime.Object{
+				&corev1alpha1.Deployer{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      deployerName,
+					},
+					Spec: corev1alpha1.DeployerSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Image: image,
+									Resources: corev1.ResourceRequirements{
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("100m"),
+											corev1.ResourceMemory: resource.MustParse("128Mi"),
 										},
 									},
 								},

--- a/pkg/validation/quantity.go
+++ b/pkg/validation/quantity.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package validation
+
+import (
+	"github.com/projectriff/cli/pkg/cli"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func Quantity(str, field string) cli.FieldErrors {
+	errs := cli.FieldErrors{}
+
+	if _, err := resource.ParseQuantity(str); err != nil {
+		// TODO capture info about why the quantity is invalid
+		errs = errs.Also(cli.ErrInvalidValue(str, field))
+	}
+
+	return errs
+}

--- a/pkg/validation/quantity_test.go
+++ b/pkg/validation/quantity_test.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package validation_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/projectriff/cli/pkg/cli"
+	rifftesting "github.com/projectriff/cli/pkg/testing"
+	"github.com/projectriff/cli/pkg/validation"
+)
+
+func TestQuantity(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected cli.FieldErrors
+		value    string
+	}{{
+		name:     "valid",
+		expected: cli.FieldErrors{},
+		value:    "2",
+	}, {
+		name:     "valid units",
+		expected: cli.FieldErrors{},
+		value:    "2M",
+	}, {
+		name:     "empty",
+		expected: cli.ErrInvalidValue("", rifftesting.TestField),
+		value:    "",
+	}, {
+		name:     "invalid",
+		expected: cli.ErrInvalidValue("/", rifftesting.TestField),
+		value:    "/",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			expected := test.expected
+			actual := validation.Quantity(test.value, rifftesting.TestField)
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("%s() = (-expected, +actual): %s", test.name, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds `--limit-cpu` and `--limit-memory` flags for the
`riff {core,knative} deployer create` commands. These values are set on
the container's .resources.limits.{cpu,memory}.

While we only set the limits, a limit without a request is equivalent to
setting the request to the limit's value.

Fixes #67