### PR TITLE
Use go 1.13's wrapped error support for silent errors

### DIFF
--- a/cmd/riff/main.go
+++ b/cmd/riff/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
 
@@ -38,7 +39,7 @@ func main() {
 	if err := cmd.Execute(); err != nil {
 		// silent errors should not log, but still exit with an error code
 		// typically the command has already been logged with more detail
-		if !cli.IsSilent(err) {
+		if !errors.Is(err, cli.SilentError) {
 			c.Errorf("Error executing command:\n")
 
 			if aggregate, ok := err.(utilerrors.Aggregate); ok {

--- a/pkg/build/commands/application_create_test.go
+++ b/pkg/build/commands/application_create_test.go
@@ -18,6 +18,7 @@ package commands_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	goruntime "runtime"
 	"strings"
@@ -989,7 +990,7 @@ To continue watching logs run: riff application tail my-application --namespace 
 `,
 			ShouldError: true,
 			Verify: func(t *testing.T, output string, err error) {
-				if actual := err; !cli.IsSilent(err) {
+				if actual := err; !errors.Is(err, cli.SilentError) {
 					t.Errorf("expected error to be silent, actual %#v", actual)
 				}
 			},

--- a/pkg/build/commands/container_create_test.go
+++ b/pkg/build/commands/container_create_test.go
@@ -18,6 +18,7 @@ package commands_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/projectriff/cli/pkg/build/commands"
@@ -281,7 +282,7 @@ To continue watching logs run: riff container tail my-container --namespace defa
 `,
 			ShouldError: true,
 			Verify: func(t *testing.T, output string, err error) {
-				if actual := err; !cli.IsSilent(err) {
+				if actual := err; !errors.Is(err, cli.SilentError) {
 					t.Errorf("expected error to be silent, actual %#v", actual)
 				}
 			},

--- a/pkg/build/commands/function_create_test.go
+++ b/pkg/build/commands/function_create_test.go
@@ -18,6 +18,7 @@ package commands_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	goruntime "runtime"
 	"strings"
@@ -1028,7 +1029,7 @@ To continue watching logs run: riff function tail my-function --namespace defaul
 `,
 			ShouldError: true,
 			Verify: func(t *testing.T, output string, err error) {
-				if actual := err; !cli.IsSilent(err) {
+				if actual := err; !errors.Is(err, cli.SilentError) {
 					t.Errorf("expected error to be silent, actual %#v", actual)
 				}
 			},

--- a/pkg/cli/errors.go
+++ b/pkg/cli/errors.go
@@ -16,21 +16,25 @@
 
 package cli
 
-type SilentError struct {
-	Err error
+var SilentError = &silentError{}
+
+type silentError struct {
+	err error
 }
 
-func (e *SilentError) Error() string {
-	return e.Err.Error()
+func (e *silentError) Error() string {
+	return e.err.Error()
+}
+
+func (e *silentError) Unwrap() error {
+	return e.err
+}
+
+func (e *silentError) Is(err error) bool {
+	_, ok := err.(*silentError)
+	return ok
 }
 
 func SilenceError(err error) error {
-	return &SilentError{
-		Err: err,
-	}
-}
-
-func IsSilent(err error) bool {
-	_, ok := err.(*SilentError)
-	return ok
+	return &silentError{err: err}
 }

--- a/pkg/cli/errors_test.go
+++ b/pkg/cli/errors_test.go
@@ -17,6 +17,7 @@
 package cli_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -27,11 +28,14 @@ func TestSilenceError(t *testing.T) {
 	err := fmt.Errorf("test error")
 	silentErr := cli.SilenceError(err)
 
-	if cli.IsSilent(err) {
+	if errors.Is(err, cli.SilentError) {
 		t.Errorf("expected error to not be silent, got %#v", err)
 	}
-	if !cli.IsSilent(silentErr) {
+	if !errors.Is(silentErr, cli.SilentError) {
 		t.Errorf("expected error to be silent, got %#v", err)
+	}
+	if expected, actual := err, errors.Unwrap(silentErr); expected != actual {
+		t.Errorf("errors expected to match, expected %v, actually %v", expected, actual)
 	}
 	if expected, actual := err.Error(), silentErr.Error(); expected != actual {
 		t.Errorf("errors expected to match, expected %q, actually %q", expected, actual)

--- a/pkg/core/commands/deployer_create_test.go
+++ b/pkg/core/commands/deployer_create_test.go
@@ -18,6 +18,7 @@ package commands_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -578,7 +579,7 @@ To continue watching logs run: riff core deployer tail my-deployer --namespace d
 `,
 			ShouldError: true,
 			Verify: func(t *testing.T, output string, err error) {
-				if actual := err; !cli.IsSilent(err) {
+				if actual := err; !errors.Is(err, cli.SilentError) {
 					t.Errorf("expected error to be silent, actual %#v", actual)
 				}
 			},

--- a/pkg/knative/commands/adapter_create_test.go
+++ b/pkg/knative/commands/adapter_create_test.go
@@ -18,6 +18,7 @@ package commands_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/projectriff/cli/pkg/cli"
@@ -449,7 +450,7 @@ To view status run: riff knative adapter list --namespace default
 `,
 			ShouldError: true,
 			Verify: func(t *testing.T, output string, err error) {
-				if actual := err; !cli.IsSilent(err) {
+				if actual := err; !errors.Is(err, cli.SilentError) {
 					t.Errorf("expected error to be silent, actual %#v", actual)
 				}
 			},

--- a/pkg/knative/commands/deployer_create_test.go
+++ b/pkg/knative/commands/deployer_create_test.go
@@ -18,6 +18,7 @@ package commands_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -578,7 +579,7 @@ To continue watching logs run: riff knative deployer tail my-deployer --namespac
 `,
 			ShouldError: true,
 			Verify: func(t *testing.T, output string, err error) {
-				if actual := err; !cli.IsSilent(err) {
+				if actual := err; !errors.Is(err, cli.SilentError) {
 					t.Errorf("expected error to be silent, actual %#v", actual)
 				}
 			},

--- a/pkg/streaming/commands/processor_create_test.go
+++ b/pkg/streaming/commands/processor_create_test.go
@@ -18,6 +18,7 @@ package commands_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -392,7 +393,7 @@ To continue watching logs run: riff processor tail my-processor --namespace defa
 `,
 			ShouldError: true,
 			Verify: func(t *testing.T, output string, err error) {
-				if actual := err; !cli.IsSilent(err) {
+				if actual := err; !errors.Is(err, cli.SilentError) {
 					t.Errorf("expected error to be silent, actual %#v", actual)
 				}
 			},


### PR DESCRIPTION
See https://blog.golang.org/go1.13-errors