### PR TITLE
Consume latest riff system

### DIFF
--- a/ci/fats-cleanup.sh
+++ b/ci/fats-cleanup.sh
@@ -18,6 +18,9 @@ if [ -d "$fats_dir" ]; then
   kubectl delete customresourcedefinitions.apiextensions.k8s.io -l app.kubernetes.io/managed-by=Tiller,app.kubernetes.io/instance=istio
   kubectl delete namespace istio-system
 
+  helm delete --purge cert-manager
+  kubectl delete customresourcedefinitions.apiextensions.k8s.io -l app.kubernetes.io/managed-by=Tiller,app.kubernetes.io/instance=cert-manager
+
   source $fats_dir/macros/helm-reset.sh
   source $fats_dir/cleanup.sh
 fi


### PR DESCRIPTION
Install cert-manager independently so the resource webhook can consume
it.