### PR TITLE
Add --ingress-policy for deployers

### DIFF
--- a/docs/riff_core_deployer_create.md
+++ b/docs/riff_core_deployer_create.md
@@ -41,6 +41,7 @@ riff core deployer create my-image-deployer --image registry.example.com/my-imag
       --function-ref name       name of function to deploy
   -h, --help                    help for create
       --image image             container image to deploy
+      --ingress-policy policy   ingress policy for network access to the workload, one of "ClusterLocal" or "External" (default "External")
       --limit-cpu cores         the maximum amount of cpu allowed, in CPU cores (500m = .5 cores)
       --limit-memory bytes      the maximum amount of memory allowed, in bytes (500Mi = 500MiB = 500 * 1024 * 1024)
   -n, --namespace name          kubernetes namespace (defaulted from kube config)

--- a/docs/riff_knative_deployer_create.md
+++ b/docs/riff_knative_deployer_create.md
@@ -41,6 +41,7 @@ riff knative deployer create my-image-deployer --image registry.example.com/my-i
       --function-ref name       name of function to deploy
   -h, --help                    help for create
       --image image             container image to deploy
+      --ingress-policy policy   ingress policy for network access to the workload, one of "ClusterLocal" or "External" (default "External")
       --limit-cpu cores         the maximum amount of cpu allowed, in CPU cores (500m = .5 cores)
       --limit-memory bytes      the maximum amount of memory allowed, in bytes (500Mi = 500MiB = 500 * 1024 * 1024)
   -n, --namespace name          kubernetes namespace (defaulted from kube config)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.3.1
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/projectriff/system v0.0.0-20191119095659-80119a4cf209
+	github.com/projectriff/system v0.0.0-20191120234226-fe8b3d054ce9
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.5.0
 	github.com/stretchr/testify v1.4.0
@@ -22,5 +22,3 @@ require (
 	k8s.io/apimachinery v0.0.0-20191028221656-72ed19daf4bb
 	k8s.io/client-go v0.0.0-20191114101535-6c5935290e33
 )
-
-replace github.com/projectriff/system => github.com/scothis/system v0.0.0-20191119202523-36255c577716

--- a/go.mod
+++ b/go.mod
@@ -22,3 +22,5 @@ require (
 	k8s.io/apimachinery v0.0.0-20191028221656-72ed19daf4bb
 	k8s.io/client-go v0.0.0-20191114101535-6c5935290e33
 )
+
+replace github.com/projectriff/system => github.com/scothis/system v0.0.0-20191119202523-36255c577716

--- a/go.sum
+++ b/go.sum
@@ -405,6 +405,8 @@ github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
+github.com/projectriff/system v0.0.0-20191120234226-fe8b3d054ce9 h1:DK3TSg/RePwNJyXMbw7hJ1+0VK+ByWPkrzyFO7A1d/k=
+github.com/projectriff/system v0.0.0-20191120234226-fe8b3d054ce9/go.mod h1:lwyBKyPbM4udDu1wFDtzimhKVDv2iIemlYtiWVaAwWQ=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
 github.com/prometheus/client_golang v0.9.3 h1:9iH4JKXLzFbOAdtqv/a+j8aewx2Y8lAjAydhbaScPF8=
@@ -429,8 +431,6 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/sclevine/spec v1.0.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sclevine/spec v1.2.0 h1:1Jwdf9jSfDl9NVmt8ndHqbTZ7XCCPbh1jI3hkDBHVYA=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
-github.com/scothis/system v0.0.0-20191119202523-36255c577716 h1:eV46TdAKcucNghW8E4zi8Noklc6KezqkQkVH0BiyQpo=
-github.com/scothis/system v0.0.0-20191119202523-36255c577716/go.mod h1:lwyBKyPbM4udDu1wFDtzimhKVDv2iIemlYtiWVaAwWQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sirupsen/logrus v1.1.1/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,6 @@ github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
-github.com/projectriff/system v0.0.0-20191119095659-80119a4cf209 h1:YtP3GU/GJVWKv7ZbKpeLbG9XmQPhRn8db6NP5/zM3nI=
-github.com/projectriff/system v0.0.0-20191119095659-80119a4cf209/go.mod h1:lwyBKyPbM4udDu1wFDtzimhKVDv2iIemlYtiWVaAwWQ=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
 github.com/prometheus/client_golang v0.9.3 h1:9iH4JKXLzFbOAdtqv/a+j8aewx2Y8lAjAydhbaScPF8=
@@ -431,6 +429,8 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/sclevine/spec v1.0.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sclevine/spec v1.2.0 h1:1Jwdf9jSfDl9NVmt8ndHqbTZ7XCCPbh1jI3hkDBHVYA=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
+github.com/scothis/system v0.0.0-20191119202523-36255c577716 h1:eV46TdAKcucNghW8E4zi8Noklc6KezqkQkVH0BiyQpo=
+github.com/scothis/system v0.0.0-20191119202523-36255c577716/go.mod h1:lwyBKyPbM4udDu1wFDtzimhKVDv2iIemlYtiWVaAwWQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sirupsen/logrus v1.1.1/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -45,6 +45,7 @@ const (
 	GitRevisionFlagName           = "--git-revision"
 	HandlerFlagName               = "--handler"
 	ImageFlagName                 = "--image"
+	IngressPolicyFlagName         = "--ingress-policy"
 	InputFlagName                 = "--input"
 	InvokerFlagName               = "--invoker"
 	KubeConfigFlagName            = "--kubeconfig"

--- a/pkg/core/commands/deployer_create.go
+++ b/pkg/core/commands/deployer_create.go
@@ -43,6 +43,8 @@ type DeployerCreateOptions struct {
 	ContainerRef   string
 	FunctionRef    string
 
+	IngressPolicy string
+
 	Env     []string
 	EnvFrom []string
 
@@ -100,6 +102,10 @@ func (opts *DeployerCreateOptions) Validate(ctx context.Context) cli.FieldErrors
 		errs = errs.Also(cli.ErrMultipleOneOf(used...))
 	}
 
+	if opts.IngressPolicy != string(corev1alpha1.IngressPolicyClusterLocal) && opts.IngressPolicy != string(corev1alpha1.IngressPolicyExternal) {
+		errs = errs.Also(cli.ErrInvalidValue(opts.IngressPolicy, cli.IngressPolicyFlagName))
+	}
+
 	errs = errs.Also(validation.EnvVars(opts.Env, cli.EnvFlagName))
 	errs = errs.Also(validation.EnvVarFroms(opts.EnvFrom, cli.EnvFromFlagName))
 
@@ -135,6 +141,7 @@ func (opts *DeployerCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 			Template: &corev1.PodSpec{
 				Containers: []corev1.Container{{}},
 			},
+			IngressPolicy: corev1alpha1.IngressPolicy(opts.IngressPolicy),
 		},
 	}
 
@@ -259,6 +266,8 @@ and ` + cli.EnvFromFlagName + ` to map values from a ConfigMap or Secret.
 	_ = cmd.MarkFlagCustom(cli.StripDash(cli.ContainerRefFlagName), "__"+c.Name+"_list_containers")
 	cmd.Flags().StringVar(&opts.FunctionRef, cli.StripDash(cli.FunctionRefFlagName), "", "`name` of function to deploy")
 	_ = cmd.MarkFlagCustom(cli.StripDash(cli.FunctionRefFlagName), "__"+c.Name+"_list_functions")
+	cmd.Flags().StringVar(&opts.IngressPolicy, cli.StripDash(cli.IngressPolicyFlagName), string(corev1alpha1.IngressPolicyExternal), fmt.Sprintf("ingress `policy` for network access to the workload, one of %q or %q", corev1alpha1.IngressPolicyClusterLocal, corev1alpha1.IngressPolicyExternal))
+	_ = cmd.MarkFlagCustom(cli.StripDash(cli.IngressPolicyFlagName), "__"+c.Name+"_ingress_policy")
 	cmd.Flags().StringArrayVar(&opts.Env, cli.StripDash(cli.EnvFlagName), []string{}, fmt.Sprintf("environment `variable` defined as a key value pair separated by an equals sign, example %q (may be set multiple times)", fmt.Sprintf("%s MY_VAR=my-value", cli.EnvFlagName)))
 	cmd.Flags().StringArrayVar(&opts.EnvFrom, cli.StripDash(cli.EnvFromFlagName), []string{}, fmt.Sprintf("environment `variable` from a config map or secret, example %q, %q (may be set multiple times)", fmt.Sprintf("%s MY_SECRET_VALUE=secretKeyRef:my-secret-name:key-in-secret", cli.EnvFromFlagName), fmt.Sprintf("%s MY_CONFIG_MAP_VALUE=configMapKeyRef:my-config-map-name:key-in-config-map", cli.EnvFromFlagName)))
 	cmd.Flags().StringVar(&opts.LimitCPU, cli.StripDash(cli.LimitCPUFlagName), "", "the maximum amount of cpu allowed, in CPU `cores` (500m = .5 cores)")

--- a/pkg/core/commands/deployer_create_test.go
+++ b/pkg/core/commands/deployer_create_test.go
@@ -45,6 +45,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			},
 			ExpectFieldErrors: rifftesting.InvalidResourceOptionsFieldError.Also(
 				cli.ErrMissingOneOf(cli.ApplicationRefFlagName, cli.ContainerRefFlagName, cli.FunctionRefFlagName, cli.ImageFlagName),
+				cli.ErrInvalidValue("", cli.IngressPolicyFlagName),
 			),
 		},
 		{
@@ -52,6 +53,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				ApplicationRef:  "my-application",
+				IngressPolicy:   string(corev1alpha1.IngressPolicyClusterLocal),
 			},
 			ShouldValidate: true,
 		},
@@ -60,6 +62,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				ContainerRef:    "my-container",
+				IngressPolicy:   string(corev1alpha1.IngressPolicyClusterLocal),
 			},
 			ShouldValidate: true,
 		},
@@ -68,6 +71,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				FunctionRef:     "my-function",
+				IngressPolicy:   string(corev1alpha1.IngressPolicyClusterLocal),
 			},
 			ShouldValidate: true,
 		},
@@ -76,6 +80,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(corev1alpha1.IngressPolicyClusterLocal),
 			},
 			ShouldValidate: true,
 		},
@@ -87,14 +92,34 @@ func TestDeployerCreateOptions(t *testing.T) {
 				ContainerRef:    "my-container",
 				FunctionRef:     "my-function",
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(corev1alpha1.IngressPolicyClusterLocal),
 			},
 			ExpectFieldErrors: cli.ErrMultipleOneOf(cli.ApplicationRefFlagName, cli.ContainerRefFlagName, cli.FunctionRefFlagName, cli.ImageFlagName),
+		},
+		{
+			Name: "with external ingress",
+			Options: &commands.DeployerCreateOptions{
+				ResourceOptions: rifftesting.ValidResourceOptions,
+				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(corev1alpha1.IngressPolicyExternal),
+			},
+			ShouldValidate: true,
+		},
+		{
+			Name: "with bogus ingress",
+			Options: &commands.DeployerCreateOptions{
+				ResourceOptions: rifftesting.ValidResourceOptions,
+				Image:           "example.com/repo:tag",
+				IngressPolicy:   "bogus",
+			},
+			ExpectFieldErrors: cli.ErrInvalidValue("bogus", cli.IngressPolicyFlagName),
 		},
 		{
 			Name: "with env",
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(corev1alpha1.IngressPolicyClusterLocal),
 				Env:             []string{"VAR1=foo", "VAR2=bar"},
 			},
 			ShouldValidate: true,
@@ -104,6 +129,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(corev1alpha1.IngressPolicyClusterLocal),
 				Env:             []string{"=foo"},
 			},
 			ExpectFieldErrors: cli.ErrInvalidArrayValue("=foo", cli.EnvFlagName, 0),
@@ -113,6 +139,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(corev1alpha1.IngressPolicyClusterLocal),
 				EnvFrom:         []string{"VAR1=secretKeyRef:name:key"},
 			},
 			ShouldValidate: true,
@@ -122,6 +149,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(corev1alpha1.IngressPolicyClusterLocal),
 				EnvFrom:         []string{"VAR1=configMapKeyRef:name:key"},
 			},
 			ShouldValidate: true,
@@ -131,6 +159,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(corev1alpha1.IngressPolicyClusterLocal),
 				EnvFrom:         []string{"VAR1=someOtherKeyRef:name:key"},
 			},
 			ExpectFieldErrors: cli.ErrInvalidArrayValue("VAR1=someOtherKeyRef:name:key", cli.EnvFromFlagName, 0),
@@ -140,6 +169,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(corev1alpha1.IngressPolicyClusterLocal),
 				LimitCPU:        "500m",
 				LimitMemory:     "512Mi",
 			},
@@ -150,6 +180,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(corev1alpha1.IngressPolicyClusterLocal),
 				LimitCPU:        "50%",
 				LimitMemory:     "NaN",
 			},
@@ -163,6 +194,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(corev1alpha1.IngressPolicyClusterLocal),
 				Tail:            true,
 				WaitTimeout:     "10m",
 			},
@@ -173,6 +205,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(corev1alpha1.IngressPolicyClusterLocal),
 				Tail:            true,
 			},
 			ExpectFieldErrors: cli.ErrMissingField(cli.WaitTimeoutFlagName),
@@ -182,6 +215,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(corev1alpha1.IngressPolicyClusterLocal),
 				Tail:            true,
 				WaitTimeout:     "d",
 			},
@@ -192,6 +226,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(corev1alpha1.IngressPolicyClusterLocal),
 				DryRun:          true,
 			},
 			ShouldValidate: true,
@@ -201,6 +236,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(corev1alpha1.IngressPolicyClusterLocal),
 				Tail:            true,
 				WaitTimeout:     "10m",
 				DryRun:          true,
@@ -249,6 +285,7 @@ func TestDeployerCreateCommand(t *testing.T) {
 								{Image: image},
 							},
 						},
+						IngressPolicy: corev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -269,6 +306,7 @@ Created deployer "my-deployer"
 						Build: &corev1alpha1.Build{
 							ApplicationRef: applicationRef,
 						},
+						IngressPolicy: corev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -289,6 +327,7 @@ Created deployer "my-deployer"
 						Build: &corev1alpha1.Build{
 							ContainerRef: containerRef,
 						},
+						IngressPolicy: corev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -309,6 +348,7 @@ Created deployer "my-deployer"
 						Build: &corev1alpha1.Build{
 							FunctionRef: functionRef,
 						},
+						IngressPolicy: corev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -328,6 +368,7 @@ metadata:
   name: my-deployer
   namespace: default
 spec:
+  ingressPolicy: External
   template:
     containers:
     - image: registry.example.com/repo@sha256:deadbeefdeadbeefdeadbeefdeadbeef
@@ -335,6 +376,29 @@ spec:
       resources: {}
 status: {}
 
+Created deployer "my-deployer"
+`,
+		},
+		{
+			Name: "create from cluster-local ingress policy",
+			Args: []string{deployerName, cli.ImageFlagName, image, cli.IngressPolicyFlagName, string(corev1alpha1.IngressPolicyClusterLocal)},
+			ExpectCreates: []runtime.Object{
+				&corev1alpha1.Deployer{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      deployerName,
+					},
+					Spec: corev1alpha1.DeployerSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Image: image},
+							},
+						},
+						IngressPolicy: corev1alpha1.IngressPolicyClusterLocal,
+					},
+				},
+			},
+			ExpectOutput: `
 Created deployer "my-deployer"
 `,
 		},
@@ -381,6 +445,7 @@ Created deployer "my-deployer"
 								},
 							},
 						},
+						IngressPolicy: corev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -411,6 +476,7 @@ Created deployer "my-deployer"
 								},
 							},
 						},
+						IngressPolicy: corev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -441,6 +507,7 @@ Created deployer "my-deployer"
 								{Image: image},
 							},
 						},
+						IngressPolicy: corev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -464,6 +531,7 @@ Created deployer "my-deployer"
 								{Image: image},
 							},
 						},
+						IngressPolicy: corev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -487,6 +555,7 @@ Created deployer "my-deployer"
 						Template: &corev1.PodSpec{
 							Containers: []corev1.Container{{Image: image}},
 						},
+						IngressPolicy: corev1alpha1.IngressPolicyExternal,
 					},
 				}, cli.TailSinceCreateDefault, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 					fmt.Fprintf(c.Stdout, "...log output...\n")
@@ -512,6 +581,7 @@ Created deployer "my-deployer"
 						Template: &corev1.PodSpec{
 							Containers: []corev1.Container{{Image: image}},
 						},
+						IngressPolicy: corev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -539,6 +609,7 @@ Deployer "my-deployer" is ready
 						Template: &corev1.PodSpec{
 							Containers: []corev1.Container{{Image: image}},
 						},
+						IngressPolicy: corev1alpha1.IngressPolicyExternal,
 					},
 				}, cli.TailSinceCreateDefault, mock.Anything).Return(k8s.ErrWaitTimeout).Run(func(args mock.Arguments) {
 					ctx := args[0].(context.Context)
@@ -567,6 +638,7 @@ Deployer "my-deployer" is ready
 						Template: &corev1.PodSpec{
 							Containers: []corev1.Container{{Image: image}},
 						},
+						IngressPolicy: corev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -602,6 +674,7 @@ To continue watching logs run: riff core deployer tail my-deployer --namespace d
 						Template: &corev1.PodSpec{
 							Containers: []corev1.Container{{Image: image}},
 						},
+						IngressPolicy: corev1alpha1.IngressPolicyExternal,
 					},
 				}, cli.TailSinceCreateDefault, mock.Anything).Return(fmt.Errorf("kail error"))
 				return ctx, nil
@@ -625,6 +698,7 @@ To continue watching logs run: riff core deployer tail my-deployer --namespace d
 						Template: &corev1.PodSpec{
 							Containers: []corev1.Container{{Image: image}},
 						},
+						IngressPolicy: corev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},

--- a/pkg/core/commands/deployer_list.go
+++ b/pkg/core/commands/deployer_list.go
@@ -118,11 +118,20 @@ func (opts *DeployerListOptions) print(deployer *corev1alpha1.Deployer, _ printe
 		Object: runtime.RawExtension{Object: deployer},
 	}
 	refType, refValue := opts.formatRef(deployer)
+	var url string
+	switch deployer.Spec.IngressPolicy {
+	case corev1alpha1.IngressPolicyClusterLocal:
+		url = deployer.Status.Address.URL
+	case corev1alpha1.IngressPolicyExternal:
+		url = deployer.Status.URL
+	default:
+		url = deployer.Status.URL
+	}
 	row.Cells = append(row.Cells,
 		deployer.Name,
 		refType,
 		refValue,
-		cli.FormatEmptyString(deployer.Status.ServiceName),
+		cli.FormatEmptyString(url),
 		cli.FormatConditionStatus(deployer.Status.GetCondition(corev1alpha1.DeployerConditionReady)),
 		cli.FormatTimestampSince(deployer.CreationTimestamp, now),
 	)
@@ -134,7 +143,7 @@ func (opts *DeployerListOptions) printColumns() []metav1beta1.TableColumnDefinit
 		{Name: "Name", Type: "string"},
 		{Name: "Type", Type: "string"},
 		{Name: "Ref", Type: "string"},
-		{Name: "Service", Type: "string"},
+		{Name: "URL", Type: "string"},
 		{Name: "Status", Type: "string"},
 		{Name: "Age", Type: "string"},
 	}

--- a/pkg/core/commands/deployer_list_test.go
+++ b/pkg/core/commands/deployer_list_test.go
@@ -87,7 +87,7 @@ No deployers found.
 				},
 			},
 			ExpectOutput: `
-NAME            TYPE        REF         SERVICE   STATUS      AGE
+NAME            TYPE        REF         URL       STATUS      AGE
 test-deployer   <unknown>   <unknown>   <empty>   <unknown>   <unknown>
 `,
 		},
@@ -124,7 +124,7 @@ No deployers found.
 				},
 			},
 			ExpectOutput: `
-NAMESPACE         NAME                  TYPE        REF         SERVICE   STATUS      AGE
+NAMESPACE         NAME                  TYPE        REF         URL       STATUS      AGE
 default           test-deployer         <unknown>   <unknown>   <empty>   <unknown>   <unknown>
 other-namespace   test-other-deployer   <unknown>   <unknown>   <empty>   <unknown>   <unknown>
 `,
@@ -151,8 +151,10 @@ other-namespace   test-other-deployer   <unknown>   <unknown>   <empty>   <unkno
 								{Type: corev1alpha1.DeployerConditionReady, Status: "True"},
 							},
 						},
-						DeploymentName: "img-deployer",
-						ServiceName:    "img-deployer",
+						Address: &apis.Addressable{
+							URL: "img.default.svc.cluster.local",
+						},
+						URL: "img.default.example.com",
 					},
 				},
 				&corev1alpha1.Deployer{
@@ -161,7 +163,8 @@ other-namespace   test-other-deployer   <unknown>   <unknown>   <empty>   <unkno
 						Namespace: defaultNamespace,
 					},
 					Spec: corev1alpha1.DeployerSpec{
-						Build: &corev1alpha1.Build{ApplicationRef: "petclinic"},
+						Build:         &corev1alpha1.Build{ApplicationRef: "petclinic"},
+						IngressPolicy: corev1alpha1.IngressPolicyExternal,
 					},
 					Status: corev1alpha1.DeployerStatus{
 						Status: apis.Status{
@@ -169,8 +172,10 @@ other-namespace   test-other-deployer   <unknown>   <unknown>   <empty>   <unkno
 								{Type: corev1alpha1.DeployerConditionReady, Status: "True"},
 							},
 						},
-						DeploymentName: "app-deployer",
-						ServiceName:    "app-deployer",
+						Address: &apis.Addressable{
+							URL: "app.default.svc.cluster.local",
+						},
+						URL: "app.default.example.com",
 					},
 				},
 				&corev1alpha1.Deployer{
@@ -179,7 +184,8 @@ other-namespace   test-other-deployer   <unknown>   <unknown>   <empty>   <unkno
 						Namespace: defaultNamespace,
 					},
 					Spec: corev1alpha1.DeployerSpec{
-						Build: &corev1alpha1.Build{FunctionRef: "square"},
+						Build:         &corev1alpha1.Build{FunctionRef: "square"},
+						IngressPolicy: corev1alpha1.IngressPolicyExternal,
 					},
 					Status: corev1alpha1.DeployerStatus{
 						Status: apis.Status{
@@ -187,8 +193,10 @@ other-namespace   test-other-deployer   <unknown>   <unknown>   <empty>   <unkno
 								{Type: corev1alpha1.DeployerConditionReady, Status: "True"},
 							},
 						},
-						DeploymentName: "func-deployer",
-						ServiceName:    "func-deployer",
+						Address: &apis.Addressable{
+							URL: "func.default.svc.cluster.local",
+						},
+						URL: "func.default.example.com",
 					},
 				},
 				&corev1alpha1.Deployer{
@@ -197,7 +205,8 @@ other-namespace   test-other-deployer   <unknown>   <unknown>   <empty>   <unkno
 						Namespace: defaultNamespace,
 					},
 					Spec: corev1alpha1.DeployerSpec{
-						Build: &corev1alpha1.Build{ContainerRef: "busybox"},
+						Build:         &corev1alpha1.Build{ContainerRef: "busybox"},
+						IngressPolicy: corev1alpha1.IngressPolicyClusterLocal,
 					},
 					Status: corev1alpha1.DeployerStatus{
 						Status: apis.Status{
@@ -205,17 +214,19 @@ other-namespace   test-other-deployer   <unknown>   <unknown>   <empty>   <unkno
 								{Type: corev1alpha1.DeployerConditionReady, Status: "True"},
 							},
 						},
-						DeploymentName: "container-deployer",
-						ServiceName:    "container-deployer",
+						Address: &apis.Addressable{
+							URL: "container.default.svc.cluster.local",
+						},
+						URL: "container.default.example.com",
 					},
 				},
 			},
 			ExpectOutput: `
-NAME        TYPE          REF                 SERVICE              STATUS   AGE
-app         application   petclinic           app-deployer         Ready    <unknown>
-container   container     busybox             container-deployer   Ready    <unknown>
-func        function      square              func-deployer        Ready    <unknown>
-img         image         projectriff/upper   img-deployer         Ready    <unknown>
+NAME        TYPE          REF                 URL                                   STATUS   AGE
+app         application   petclinic           app.default.example.com               Ready    <unknown>
+container   container     busybox             container.default.svc.cluster.local   Ready    <unknown>
+func        function      square              func.default.example.com              Ready    <unknown>
+img         image         projectriff/upper   img.default.example.com               Ready    <unknown>
 `,
 		},
 		{

--- a/pkg/knative/commands/deployer_create_test.go
+++ b/pkg/knative/commands/deployer_create_test.go
@@ -45,6 +45,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			},
 			ExpectFieldErrors: rifftesting.InvalidResourceOptionsFieldError.Also(
 				cli.ErrMissingOneOf(cli.ApplicationRefFlagName, cli.ContainerRefFlagName, cli.FunctionRefFlagName, cli.ImageFlagName),
+				cli.ErrInvalidValue("", cli.IngressPolicyFlagName),
 			),
 		},
 		{
@@ -52,6 +53,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				ApplicationRef:  "my-application",
+				IngressPolicy:   string(knativev1alpha1.IngressPolicyClusterLocal),
 			},
 			ShouldValidate: true,
 		},
@@ -60,6 +62,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				ContainerRef:    "my-container",
+				IngressPolicy:   string(knativev1alpha1.IngressPolicyClusterLocal),
 			},
 			ShouldValidate: true,
 		},
@@ -68,6 +71,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				FunctionRef:     "my-function",
+				IngressPolicy:   string(knativev1alpha1.IngressPolicyClusterLocal),
 			},
 			ShouldValidate: true,
 		},
@@ -76,6 +80,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(knativev1alpha1.IngressPolicyClusterLocal),
 			},
 			ShouldValidate: true,
 		},
@@ -87,14 +92,34 @@ func TestDeployerCreateOptions(t *testing.T) {
 				ContainerRef:    "my-container",
 				FunctionRef:     "my-function",
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(knativev1alpha1.IngressPolicyClusterLocal),
 			},
 			ExpectFieldErrors: cli.ErrMultipleOneOf(cli.ApplicationRefFlagName, cli.ContainerRefFlagName, cli.FunctionRefFlagName, cli.ImageFlagName),
+		},
+		{
+			Name: "with external ingress",
+			Options: &commands.DeployerCreateOptions{
+				ResourceOptions: rifftesting.ValidResourceOptions,
+				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(knativev1alpha1.IngressPolicyExternal),
+			},
+			ShouldValidate: true,
+		},
+		{
+			Name: "with bogus ingress",
+			Options: &commands.DeployerCreateOptions{
+				ResourceOptions: rifftesting.ValidResourceOptions,
+				Image:           "example.com/repo:tag",
+				IngressPolicy:   "bogus",
+			},
+			ExpectFieldErrors: cli.ErrInvalidValue("bogus", cli.IngressPolicyFlagName),
 		},
 		{
 			Name: "with env",
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(knativev1alpha1.IngressPolicyClusterLocal),
 				Env:             []string{"VAR1=foo", "VAR2=bar"},
 			},
 			ShouldValidate: true,
@@ -104,6 +129,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(knativev1alpha1.IngressPolicyClusterLocal),
 				Env:             []string{"=foo"},
 			},
 			ExpectFieldErrors: cli.ErrInvalidArrayValue("=foo", cli.EnvFlagName, 0),
@@ -113,6 +139,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(knativev1alpha1.IngressPolicyClusterLocal),
 				EnvFrom:         []string{"VAR1=secretKeyRef:name:key"},
 			},
 			ShouldValidate: true,
@@ -122,6 +149,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(knativev1alpha1.IngressPolicyClusterLocal),
 				EnvFrom:         []string{"VAR1=configMapKeyRef:name:key"},
 			},
 			ShouldValidate: true,
@@ -131,6 +159,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(knativev1alpha1.IngressPolicyClusterLocal),
 				EnvFrom:         []string{"VAR1=someOtherKeyRef:name:key"},
 			},
 			ExpectFieldErrors: cli.ErrInvalidArrayValue("VAR1=someOtherKeyRef:name:key", cli.EnvFromFlagName, 0),
@@ -140,6 +169,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(knativev1alpha1.IngressPolicyClusterLocal),
 				LimitCPU:        "500m",
 				LimitMemory:     "512Mi",
 			},
@@ -150,6 +180,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(knativev1alpha1.IngressPolicyClusterLocal),
 				LimitCPU:        "50%",
 				LimitMemory:     "NaN",
 			},
@@ -163,6 +194,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(knativev1alpha1.IngressPolicyClusterLocal),
 				Tail:            true,
 				WaitTimeout:     "10m",
 			},
@@ -173,6 +205,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(knativev1alpha1.IngressPolicyClusterLocal),
 				Tail:            true,
 			},
 			ExpectFieldErrors: cli.ErrMissingField(cli.WaitTimeoutFlagName),
@@ -182,6 +215,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(knativev1alpha1.IngressPolicyClusterLocal),
 				Tail:            true,
 				WaitTimeout:     "d",
 			},
@@ -192,6 +226,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(knativev1alpha1.IngressPolicyClusterLocal),
 				DryRun:          true,
 			},
 			ShouldValidate: true,
@@ -201,6 +236,7 @@ func TestDeployerCreateOptions(t *testing.T) {
 			Options: &commands.DeployerCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
 				Image:           "example.com/repo:tag",
+				IngressPolicy:   string(knativev1alpha1.IngressPolicyClusterLocal),
 				Tail:            true,
 				WaitTimeout:     "10m",
 				DryRun:          true,
@@ -249,6 +285,7 @@ func TestDeployerCreateCommand(t *testing.T) {
 								{Image: image},
 							},
 						},
+						IngressPolicy: knativev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -269,6 +306,7 @@ Created deployer "my-deployer"
 						Build: &knativev1alpha1.Build{
 							ApplicationRef: applicationRef,
 						},
+						IngressPolicy: knativev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -289,6 +327,7 @@ Created deployer "my-deployer"
 						Build: &knativev1alpha1.Build{
 							ContainerRef: containerRef,
 						},
+						IngressPolicy: knativev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -309,6 +348,7 @@ Created deployer "my-deployer"
 						Build: &knativev1alpha1.Build{
 							FunctionRef: functionRef,
 						},
+						IngressPolicy: knativev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -328,6 +368,7 @@ metadata:
   name: my-deployer
   namespace: default
 spec:
+  ingressPolicy: External
   template:
     containers:
     - image: registry.example.com/repo@sha256:deadbeefdeadbeefdeadbeefdeadbeef
@@ -335,6 +376,29 @@ spec:
       resources: {}
 status: {}
 
+Created deployer "my-deployer"
+`,
+		},
+		{
+			Name: "create from cluster-local ingress policy",
+			Args: []string{deployerName, cli.ImageFlagName, image, cli.IngressPolicyFlagName, string(knativev1alpha1.IngressPolicyClusterLocal)},
+			ExpectCreates: []runtime.Object{
+				&knativev1alpha1.Deployer{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      deployerName,
+					},
+					Spec: knativev1alpha1.DeployerSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Image: image},
+							},
+						},
+						IngressPolicy: knativev1alpha1.IngressPolicyClusterLocal,
+					},
+				},
+			},
+			ExpectOutput: `
 Created deployer "my-deployer"
 `,
 		},
@@ -381,6 +445,7 @@ Created deployer "my-deployer"
 								},
 							},
 						},
+						IngressPolicy: knativev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -411,6 +476,7 @@ Created deployer "my-deployer"
 								},
 							},
 						},
+						IngressPolicy: knativev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -441,6 +507,7 @@ Created deployer "my-deployer"
 								{Image: image},
 							},
 						},
+						IngressPolicy: knativev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -464,6 +531,7 @@ Created deployer "my-deployer"
 								{Image: image},
 							},
 						},
+						IngressPolicy: knativev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -487,6 +555,7 @@ Created deployer "my-deployer"
 						Template: &corev1.PodSpec{
 							Containers: []corev1.Container{{Image: image}},
 						},
+						IngressPolicy: knativev1alpha1.IngressPolicyExternal,
 					},
 				}, cli.TailSinceCreateDefault, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 					fmt.Fprintf(c.Stdout, "...log output...\n")
@@ -512,6 +581,7 @@ Created deployer "my-deployer"
 						Template: &corev1.PodSpec{
 							Containers: []corev1.Container{{Image: image}},
 						},
+						IngressPolicy: knativev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -539,6 +609,7 @@ Deployer "my-deployer" is ready
 						Template: &corev1.PodSpec{
 							Containers: []corev1.Container{{Image: image}},
 						},
+						IngressPolicy: knativev1alpha1.IngressPolicyExternal,
 					},
 				}, cli.TailSinceCreateDefault, mock.Anything).Return(k8s.ErrWaitTimeout).Run(func(args mock.Arguments) {
 					ctx := args[0].(context.Context)
@@ -567,6 +638,7 @@ Deployer "my-deployer" is ready
 						Template: &corev1.PodSpec{
 							Containers: []corev1.Container{{Image: image}},
 						},
+						IngressPolicy: knativev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},
@@ -602,6 +674,7 @@ To continue watching logs run: riff knative deployer tail my-deployer --namespac
 						Template: &corev1.PodSpec{
 							Containers: []corev1.Container{{Image: image}},
 						},
+						IngressPolicy: knativev1alpha1.IngressPolicyExternal,
 					},
 				}, cli.TailSinceCreateDefault, mock.Anything).Return(fmt.Errorf("kail error"))
 				return ctx, nil
@@ -625,6 +698,7 @@ To continue watching logs run: riff knative deployer tail my-deployer --namespac
 						Template: &corev1.PodSpec{
 							Containers: []corev1.Container{{Image: image}},
 						},
+						IngressPolicy: knativev1alpha1.IngressPolicyExternal,
 					},
 				},
 			},

--- a/pkg/knative/commands/deployer_list.go
+++ b/pkg/knative/commands/deployer_list.go
@@ -118,12 +118,20 @@ func (opts *DeployerListOptions) print(deployer *knativev1alpha1.Deployer, _ pri
 		Object: runtime.RawExtension{Object: deployer},
 	}
 	refType, refValue := opts.formatRef(deployer)
-	host := deployer.Status.URL
+	var url string
+	switch deployer.Spec.IngressPolicy {
+	case knativev1alpha1.IngressPolicyClusterLocal:
+		url = deployer.Status.Address.URL
+	case knativev1alpha1.IngressPolicyExternal:
+		url = deployer.Status.URL
+	default:
+		url = deployer.Status.URL
+	}
 	row.Cells = append(row.Cells,
 		deployer.Name,
 		refType,
 		refValue,
-		cli.FormatEmptyString(host),
+		cli.FormatEmptyString(url),
 		cli.FormatConditionStatus(deployer.Status.GetCondition(knativev1alpha1.DeployerConditionReady)),
 		cli.FormatTimestampSince(deployer.CreationTimestamp, now),
 	)
@@ -135,7 +143,7 @@ func (opts *DeployerListOptions) printColumns() []metav1beta1.TableColumnDefinit
 		{Name: "Name", Type: "string"},
 		{Name: "Type", Type: "string"},
 		{Name: "Ref", Type: "string"},
-		{Name: "Host", Type: "string"},
+		{Name: "URL", Type: "string"},
 		{Name: "Status", Type: "string"},
 		{Name: "Age", Type: "string"},
 	}

--- a/pkg/knative/commands/deployer_list_test.go
+++ b/pkg/knative/commands/deployer_list_test.go
@@ -87,7 +87,7 @@ No deployers found.
 				},
 			},
 			ExpectOutput: `
-NAME            TYPE        REF         HOST      STATUS      AGE
+NAME            TYPE        REF         URL       STATUS      AGE
 test-deployer   <unknown>   <unknown>   <empty>   <unknown>   <unknown>
 `,
 		},
@@ -124,7 +124,7 @@ No deployers found.
 				},
 			},
 			ExpectOutput: `
-NAMESPACE         NAME                  TYPE        REF         HOST      STATUS      AGE
+NAMESPACE         NAME                  TYPE        REF         URL       STATUS      AGE
 default           test-deployer         <unknown>   <unknown>   <empty>   <unknown>   <unknown>
 other-namespace   test-other-deployer   <unknown>   <unknown>   <empty>   <unknown>   <unknown>
 `,
@@ -151,6 +151,9 @@ other-namespace   test-other-deployer   <unknown>   <unknown>   <empty>   <unkno
 								{Type: knativev1alpha1.DeployerConditionReady, Status: "True"},
 							},
 						},
+						Address: &apis.Addressable{
+							URL: "img.default.svc.cluster.local",
+						},
 						URL: "img.default.example.com",
 					},
 				},
@@ -160,13 +163,17 @@ other-namespace   test-other-deployer   <unknown>   <unknown>   <empty>   <unkno
 						Namespace: defaultNamespace,
 					},
 					Spec: knativev1alpha1.DeployerSpec{
-						Build: &knativev1alpha1.Build{ApplicationRef: "petclinic"},
+						Build:         &knativev1alpha1.Build{ApplicationRef: "petclinic"},
+						IngressPolicy: knativev1alpha1.IngressPolicyExternal,
 					},
 					Status: knativev1alpha1.DeployerStatus{
 						Status: apis.Status{
 							Conditions: apis.Conditions{
 								{Type: knativev1alpha1.DeployerConditionReady, Status: "True"},
 							},
+						},
+						Address: &apis.Addressable{
+							URL: "app.default.svc.cluster.local",
 						},
 						URL: "app.default.example.com",
 					},
@@ -177,13 +184,17 @@ other-namespace   test-other-deployer   <unknown>   <unknown>   <empty>   <unkno
 						Namespace: defaultNamespace,
 					},
 					Spec: knativev1alpha1.DeployerSpec{
-						Build: &knativev1alpha1.Build{FunctionRef: "square"},
+						Build:         &knativev1alpha1.Build{FunctionRef: "square"},
+						IngressPolicy: knativev1alpha1.IngressPolicyExternal,
 					},
 					Status: knativev1alpha1.DeployerStatus{
 						Status: apis.Status{
 							Conditions: apis.Conditions{
 								{Type: knativev1alpha1.DeployerConditionReady, Status: "True"},
 							},
+						},
+						Address: &apis.Addressable{
+							URL: "func.default.svc.cluster.local",
 						},
 						URL: "func.default.example.com",
 					},
@@ -194,7 +205,8 @@ other-namespace   test-other-deployer   <unknown>   <unknown>   <empty>   <unkno
 						Namespace: defaultNamespace,
 					},
 					Spec: knativev1alpha1.DeployerSpec{
-						Build: &knativev1alpha1.Build{ContainerRef: "busybox"},
+						Build:         &knativev1alpha1.Build{ContainerRef: "busybox"},
+						IngressPolicy: knativev1alpha1.IngressPolicyClusterLocal,
 					},
 					Status: knativev1alpha1.DeployerStatus{
 						Status: apis.Status{
@@ -202,16 +214,19 @@ other-namespace   test-other-deployer   <unknown>   <unknown>   <empty>   <unkno
 								{Type: knativev1alpha1.DeployerConditionReady, Status: "True"},
 							},
 						},
+						Address: &apis.Addressable{
+							URL: "container.default.svc.cluster.local",
+						},
 						URL: "container.default.example.com",
 					},
 				},
 			},
 			ExpectOutput: `
-NAME        TYPE          REF                 HOST                            STATUS   AGE
-app         application   petclinic           app.default.example.com         Ready    <unknown>
-container   container     busybox             container.default.example.com   Ready    <unknown>
-func        function      square              func.default.example.com        Ready    <unknown>
-img         image         projectriff/upper   img.default.example.com         Ready    <unknown>
+NAME        TYPE          REF                 URL                                   STATUS   AGE
+app         application   petclinic           app.default.example.com               Ready    <unknown>
+container   container     busybox             container.default.svc.cluster.local   Ready    <unknown>
+func        function      square              func.default.example.com              Ready    <unknown>
+img         image         projectriff/upper   img.default.example.com               Ready    <unknown>
 `,
 		},
 		{

--- a/pkg/riff/commands/completion.go
+++ b/pkg/riff/commands/completion.go
@@ -157,6 +157,11 @@ __` + c.Name + `_list_resource()
 	fi
 }
 
+__` + c.Name + `_ingress_policy()
+{
+	COMPREPLY=( $( compgen -W "ClusterLocal External" -- "$cur" ) )
+}
+
 __` + c.Name + `_custom_func() {
 	case ${last_command} in
 		` + c.Name + `_application_delete | ` + c.Name + `_application_status | ` + c.Name + `_application_tail)


### PR DESCRIPTION
There are two valid ingress policies:
- `External`: allow traffic via ingress
- `ClusterLocal`: do not allow traffic via ingress, traffic inside the
  cluster can access the workload

Also update deployer listing to show an appropriate URL based on the
ingress policy.

Depends on projectriff/system#191