### PR TITLE
Revert "Optional service name on riff core deployer create"

### DIFF
--- a/docs/riff_core_deployer_create.md
+++ b/docs/riff_core_deployer_create.md
@@ -47,7 +47,6 @@ riff core deployer create my-image-deployer --image registry.example.com/my-imag
       --limit-cpu cores         the maximum amount of cpu allowed, in CPU cores (500m = .5 cores)
       --limit-memory bytes      the maximum amount of memory allowed, in bytes (500Mi = 500MiB = 500 * 1024 * 1024)
   -n, --namespace name          kubernetes namespace (defaulted from kube config)
-      --service-name name       name of created service (default is a generated name)
       --tail                    watch deployer logs
       --target-port port        port that the workload listens on for traffic. The value is exposed to the workload as the PORT environment variable
       --wait-timeout duration   duration to wait for the deployer to become ready when watching logs (default "10m")

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.3.1
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/projectriff/system v0.0.0-20191129144348-09c47935c6ab
+	github.com/projectriff/system v0.0.0-20191204160418-9d634bd9b226
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.5.0
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -407,8 +407,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
 github.com/projectriff/system v0.0.0-20191120234226-fe8b3d054ce9 h1:DK3TSg/RePwNJyXMbw7hJ1+0VK+ByWPkrzyFO7A1d/k=
 github.com/projectriff/system v0.0.0-20191120234226-fe8b3d054ce9/go.mod h1:lwyBKyPbM4udDu1wFDtzimhKVDv2iIemlYtiWVaAwWQ=
-github.com/projectriff/system v0.0.0-20191129144348-09c47935c6ab h1:wco2pEGWpUlkJoNLyYyzjokBeDmYbowAL54eJ37VH7I=
-github.com/projectriff/system v0.0.0-20191129144348-09c47935c6ab/go.mod h1:lwyBKyPbM4udDu1wFDtzimhKVDv2iIemlYtiWVaAwWQ=
+github.com/projectriff/system v0.0.0-20191204160418-9d634bd9b226 h1:uoCsqyh5VxQEjcv8znBkb/CcJhG27Rr2qC5+oHQJung=
+github.com/projectriff/system v0.0.0-20191204160418-9d634bd9b226/go.mod h1:lwyBKyPbM4udDu1wFDtzimhKVDv2iIemlYtiWVaAwWQ=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
 github.com/prometheus/client_golang v0.9.3 h1:9iH4JKXLzFbOAdtqv/a+j8aewx2Y8lAjAydhbaScPF8=

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -59,7 +59,6 @@ const (
 	ProviderFlagName              = "--provider"
 	RegistryFlagName              = "--registry"
 	RegistryUserFlagName          = "--registry-user"
-	ServiceNameFlagName           = "--service-name"
 	ServiceRefFlagName            = "--service-ref"
 	SetDefaultImagePrefixFlagName = "--set-default-image-prefix"
 	ShellFlagName                 = "--shell"

--- a/pkg/core/commands/deployer_create.go
+++ b/pkg/core/commands/deployer_create.go
@@ -46,8 +46,6 @@ type DeployerCreateOptions struct {
 	IngressPolicy string
 	TargetPort    int32
 
-	ServiceName string
-
 	Env     []string
 	EnvFrom []string
 
@@ -201,8 +199,6 @@ func (opts *DeployerCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 		}
 	}
 
-	deployer.Spec.ServiceName = opts.ServiceName
-
 	if opts.DryRun {
 		cli.DryRunResource(ctx, deployer, deployer.GetGroupVersionKind())
 	} else {
@@ -288,7 +284,6 @@ and ` + cli.EnvFromFlagName + ` to map values from a ConfigMap or Secret.
 	cmd.Flags().StringArrayVar(&opts.EnvFrom, cli.StripDash(cli.EnvFromFlagName), []string{}, fmt.Sprintf("environment `variable` from a config map or secret, example %q, %q (may be set multiple times)", fmt.Sprintf("%s MY_SECRET_VALUE=secretKeyRef:my-secret-name:key-in-secret", cli.EnvFromFlagName), fmt.Sprintf("%s MY_CONFIG_MAP_VALUE=configMapKeyRef:my-config-map-name:key-in-config-map", cli.EnvFromFlagName)))
 	cmd.Flags().StringVar(&opts.LimitCPU, cli.StripDash(cli.LimitCPUFlagName), "", "the maximum amount of cpu allowed, in CPU `cores` (500m = .5 cores)")
 	cmd.Flags().StringVar(&opts.LimitMemory, cli.StripDash(cli.LimitMemoryFlagName), "", "the maximum amount of memory allowed, in `bytes` (500Mi = 500MiB = 500 * 1024 * 1024)")
-	cmd.Flags().StringVar(&opts.ServiceName, cli.StripDash(cli.ServiceNameFlagName), "", "`name` of created service (default is a generated name)")
 	cmd.Flags().BoolVar(&opts.Tail, cli.StripDash(cli.TailFlagName), false, "watch deployer logs")
 	cmd.Flags().StringVar(&opts.WaitTimeout, cli.StripDash(cli.WaitTimeoutFlagName), "10m", "`duration` to wait for the deployer to become ready when watching logs")
 	cmd.Flags().BoolVar(&opts.DryRun, cli.StripDash(cli.DryRunFlagName), false, "print kubernetes resources to stdout rather than apply them to the cluster, messages normally on stdout will be sent to stderr")

--- a/pkg/core/commands/deployer_create_test.go
+++ b/pkg/core/commands/deployer_create_test.go
@@ -508,32 +508,6 @@ Created deployer "my-deployer"
 `,
 		},
 		{
-			Name: "create with service name",
-			Args: []string{deployerName, cli.ImageFlagName, image, cli.ServiceNameFlagName, "my-service"},
-			ExpectCreates: []runtime.Object{
-				&corev1alpha1.Deployer{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: defaultNamespace,
-						Name:      deployerName,
-					},
-					Spec: corev1alpha1.DeployerSpec{
-						ServiceName: "my-service",
-						Template: &corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Image: image,
-								},
-							},
-						},
-						IngressPolicy: corev1alpha1.IngressPolicyClusterLocal,
-					},
-				},
-			},
-			ExpectOutput: `
-Created deployer "my-deployer"
-`,
-		},
-		{
 			Name: "create with target-port",
 			Args: []string{deployerName, cli.ImageFlagName, image, cli.TargetPortFlagName, "8888"},
 			ExpectCreates: []runtime.Object{


### PR DESCRIPTION
Revert "Optional service name on riff core deployer create"

Except for a docs improvement which is left in place.

Also bump dependency on system to latest and fix an impacted test.

This reverts commit 4e33200bdb196488dbef2b98db7bee5abfab7215.