### PR TITLE
Use images and container references for Processors

### DIFF
--- a/docs/riff_streaming_processor_create.md
+++ b/docs/riff_streaming_processor_create.md
@@ -24,9 +24,11 @@ riff streaming processor create my-processor --function-ref my-func --input my-i
 ### Options
 
 ```
+      --container-ref name      name of container to deploy
       --dry-run                 print kubernetes resources to stdout rather than apply them to the cluster, messages normally on stdout will be sent to stderr
-      --function-ref name       name of function build to deploy
+      --function-ref name       name of function to deploy
   -h, --help                    help for create
+      --image image             container image to deploy
       --input name              name of stream to read messages from (or parameter:stream, may be set multiple times)
   -n, --namespace name          kubernetes namespace (defaulted from kube config)
       --output name             name of stream to write messages to (or parameter:stream, may be set multiple times)

--- a/pkg/streaming/commands/processor_create_test.go
+++ b/pkg/streaming/commands/processor_create_test.go
@@ -172,7 +172,7 @@ func TestProcessorCreateOptions(t *testing.T) {
 func TestProcessorCreateCommand(t *testing.T) {
 	defaultNamespace := "default"
 	processorName := "my-processor"
-	containerRef := "my-func"
+	containerRef := "my-container"
 	functionRef := "my-func"
 	image := "my-image"
 	inputName := "input"


### PR DESCRIPTION
A processor is able to accept function refs, container refs and images.
Only the function was was exposed via the CLI. Now each option is
exposed.

Refs #136

cc @AElMehdi @yeshzaoui 