### PR TITLE
race.Run waits for tasks to exit after deadline or cancel

### DIFF
--- a/pkg/race/runner_test.go
+++ b/pkg/race/runner_test.go
@@ -34,7 +34,6 @@ func TestRun(t *testing.T) {
 	}{{
 		name:    "empty",
 		timeout: time.Millisecond,
-		err:     context.DeadlineExceeded,
 	}, {
 		name:    "return immediately",
 		timeout: time.Minute,


### PR DESCRIPTION
NOTE: This was inspired by test race conditions but changes the actual behavior of the CLI

* previously, the godoc stated that `Task`s provided to `race.Run(context.Context, time.Duration, ...Task)` SHOULD exit when context is done, with this change they MUST exit
* `race.Run` returns only after all tasks exit

Fixes #149 

This behavior change feels acceptable to me because we expect all tasks to appropriately handle canceled or timed out contexts. I think it is potentially an improvement because we would not want to move on to the next steps/output in a command while a task, like tail logs, is still printing.

If we do not find this behavior change acceptable, I believe we should delete the exiting `tail logs` tests, because the output is nondeterministic. There is no guarantee that any logs are printed before the `--wait-timeout`. We could mask the race condition in the tests by increasing the timeout, but it's my opinion that we should try to avoid race conditions in unit tests.