### PR TITLE
Add new stream provisioner resources to doctor

### DIFF
--- a/pkg/riff/commands/doctor.go
+++ b/pkg/riff/commands/doctor.go
@@ -81,7 +81,9 @@ func (opts *DoctorOptions) Exec(ctx context.Context, c *cli.Config) error {
 		accessChecks = append(accessChecks,
 			&doctorAccessCheck{Attributes: &authv1.ResourceAttributes{Namespace: opts.Namespace, Group: "streaming.projectriff.io", Resource: "processors"}, Verbs: verbs},
 			&doctorAccessCheck{Attributes: &authv1.ResourceAttributes{Namespace: opts.Namespace, Group: "streaming.projectriff.io", Resource: "streams"}, Verbs: verbs},
+			&doctorAccessCheck{Attributes: &authv1.ResourceAttributes{Namespace: opts.Namespace, Group: "streaming.projectriff.io", Resource: "inmemoryproviders"}, Verbs: verbs},
 			&doctorAccessCheck{Attributes: &authv1.ResourceAttributes{Namespace: opts.Namespace, Group: "streaming.projectriff.io", Resource: "kafkaproviders"}, Verbs: verbs},
+			&doctorAccessCheck{Attributes: &authv1.ResourceAttributes{Namespace: opts.Namespace, Group: "streaming.projectriff.io", Resource: "pulsarproviders"}, Verbs: verbs},
 		)
 	}
 	if c.Runtimes[cli.KnativeRuntime] {

--- a/pkg/riff/commands/doctor_test.go
+++ b/pkg/riff/commands/doctor_test.go
@@ -177,7 +177,9 @@ functions.build.projectriff.io      my-namespace   *          allowed   allowed
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "deployers.core.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "processors.streaming.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "streams.streaming.projectriff.io"}},
+				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "inmemoryproviders.streaming.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "kafkaproviders.streaming.projectriff.io"}},
+				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "pulsarproviders.streaming.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "adapters.knative.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "deployers.knative.projectriff.io"}},
 			},
@@ -193,7 +195,9 @@ functions.build.projectriff.io      my-namespace   *          allowed   allowed
 				selfSubjectAccessReviewRequests("default", "", "core.projectriff.io", "deployers", "", verbs...),
 				selfSubjectAccessReviewRequests("default", "", "streaming.projectriff.io", "processors", "", verbs...),
 				selfSubjectAccessReviewRequests("default", "", "streaming.projectriff.io", "streams", "", verbs...),
+				selfSubjectAccessReviewRequests("default", "", "streaming.projectriff.io", "inmemoryproviders", "", verbs...),
 				selfSubjectAccessReviewRequests("default", "", "streaming.projectriff.io", "kafkaproviders", "", verbs...),
+				selfSubjectAccessReviewRequests("default", "", "streaming.projectriff.io", "pulsarproviders", "", verbs...),
 				selfSubjectAccessReviewRequests("default", "", "knative.projectriff.io", "adapters", "", verbs...),
 				selfSubjectAccessReviewRequests("default", "", "knative.projectriff.io", "deployers", "", verbs...),
 			),
@@ -205,21 +209,23 @@ NAMESPACE     STATUS
 default       ok
 riff-system   ok
 
-RESOURCE                                  NAMESPACE     NAME       READ      WRITE
-configmaps                                riff-system   builders   allowed   n/a
-configmaps                                default       *          allowed   allowed
-secrets                                   default       *          allowed   allowed
-pods                                      default       *          allowed   n/a
-pods/log                                  default       *          allowed   n/a
-applications.build.projectriff.io         default       *          allowed   allowed
-containers.build.projectriff.io           default       *          allowed   allowed
-functions.build.projectriff.io            default       *          allowed   allowed
-deployers.core.projectriff.io             default       *          allowed   allowed
-processors.streaming.projectriff.io       default       *          allowed   allowed
-streams.streaming.projectriff.io          default       *          allowed   allowed
-kafkaproviders.streaming.projectriff.io   default       *          allowed   allowed
-adapters.knative.projectriff.io           default       *          allowed   allowed
-deployers.knative.projectriff.io          default       *          allowed   allowed
+RESOURCE                                     NAMESPACE     NAME       READ      WRITE
+configmaps                                   riff-system   builders   allowed   n/a
+configmaps                                   default       *          allowed   allowed
+secrets                                      default       *          allowed   allowed
+pods                                         default       *          allowed   n/a
+pods/log                                     default       *          allowed   n/a
+applications.build.projectriff.io            default       *          allowed   allowed
+containers.build.projectriff.io              default       *          allowed   allowed
+functions.build.projectriff.io               default       *          allowed   allowed
+deployers.core.projectriff.io                default       *          allowed   allowed
+processors.streaming.projectriff.io          default       *          allowed   allowed
+streams.streaming.projectriff.io             default       *          allowed   allowed
+inmemoryproviders.streaming.projectriff.io   default       *          allowed   allowed
+kafkaproviders.streaming.projectriff.io      default       *          allowed   allowed
+pulsarproviders.streaming.projectriff.io     default       *          allowed   allowed
+adapters.knative.projectriff.io              default       *          allowed   allowed
+deployers.knative.projectriff.io             default       *          allowed   allowed
 `,
 		},
 		{
@@ -277,7 +283,9 @@ deployers.core.projectriff.io       default       *          allowed   allowed
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "functions.build.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "processors.streaming.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "streams.streaming.projectriff.io"}},
+				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "inmemoryproviders.streaming.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "kafkaproviders.streaming.projectriff.io"}},
+				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "pulsarproviders.streaming.projectriff.io"}},
 			},
 			ExpectCreates: merge(
 				selfSubjectAccessReviewRequests("riff-system", "builders", "core", "configmaps", "", readVerbs...),
@@ -290,7 +298,9 @@ deployers.core.projectriff.io       default       *          allowed   allowed
 				selfSubjectAccessReviewRequests("default", "", "build.projectriff.io", "functions", "", verbs...),
 				selfSubjectAccessReviewRequests("default", "", "streaming.projectriff.io", "processors", "", verbs...),
 				selfSubjectAccessReviewRequests("default", "", "streaming.projectriff.io", "streams", "", verbs...),
+				selfSubjectAccessReviewRequests("default", "", "streaming.projectriff.io", "inmemoryproviders", "", verbs...),
 				selfSubjectAccessReviewRequests("default", "", "streaming.projectriff.io", "kafkaproviders", "", verbs...),
+				selfSubjectAccessReviewRequests("default", "", "streaming.projectriff.io", "pulsarproviders", "", verbs...),
 			),
 			WithReactors: []rifftesting.ReactionFunc{
 				passAccessReview(),
@@ -300,18 +310,20 @@ NAMESPACE     STATUS
 default       ok
 riff-system   ok
 
-RESOURCE                                  NAMESPACE     NAME       READ      WRITE
-configmaps                                riff-system   builders   allowed   n/a
-configmaps                                default       *          allowed   allowed
-secrets                                   default       *          allowed   allowed
-pods                                      default       *          allowed   n/a
-pods/log                                  default       *          allowed   n/a
-applications.build.projectriff.io         default       *          allowed   allowed
-containers.build.projectriff.io           default       *          allowed   allowed
-functions.build.projectriff.io            default       *          allowed   allowed
-processors.streaming.projectriff.io       default       *          allowed   allowed
-streams.streaming.projectriff.io          default       *          allowed   allowed
-kafkaproviders.streaming.projectriff.io   default       *          allowed   allowed
+RESOURCE                                     NAMESPACE     NAME       READ      WRITE
+configmaps                                   riff-system   builders   allowed   n/a
+configmaps                                   default       *          allowed   allowed
+secrets                                      default       *          allowed   allowed
+pods                                         default       *          allowed   n/a
+pods/log                                     default       *          allowed   n/a
+applications.build.projectriff.io            default       *          allowed   allowed
+containers.build.projectriff.io              default       *          allowed   allowed
+functions.build.projectriff.io               default       *          allowed   allowed
+processors.streaming.projectriff.io          default       *          allowed   allowed
+streams.streaming.projectriff.io             default       *          allowed   allowed
+inmemoryproviders.streaming.projectriff.io   default       *          allowed   allowed
+kafkaproviders.streaming.projectriff.io      default       *          allowed   allowed
+pulsarproviders.streaming.projectriff.io     default       *          allowed   allowed
 `,
 		},
 		{
@@ -458,7 +470,9 @@ functions.build.projectriff.io      default       *          mixed   allowed
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "deployers.core.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "processors.streaming.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "streams.streaming.projectriff.io"}},
+				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "inmemoryproviders.streaming.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "kafkaproviders.streaming.projectriff.io"}},
+				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "pulsarproviders.streaming.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "adapters.knative.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "deployers.knative.projectriff.io"}},
 			},
@@ -480,7 +494,9 @@ functions.build.projectriff.io      default       *          mixed   allowed
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "deployers.core.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "processors.streaming.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "streams.streaming.projectriff.io"}},
+				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "inmemoryproviders.streaming.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "kafkaproviders.streaming.projectriff.io"}},
+				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "pulsarproviders.streaming.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "adapters.knative.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "deployers.knative.projectriff.io"}},
 			},
@@ -510,7 +526,9 @@ functions.build.projectriff.io      default       *          mixed   allowed
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "deployers.core.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "processors.streaming.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "streams.streaming.projectriff.io"}},
+				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "inmemoryproviders.streaming.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "kafkaproviders.streaming.projectriff.io"}},
+				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "pulsarproviders.streaming.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "adapters.knative.projectriff.io"}},
 				&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "deployers.knative.projectriff.io"}},
 			},


### PR DESCRIPTION
InMemoryProvider and PulsarProvider are supported by the CLI, but were not introduced to the doctor.