### PR TITLE
Clarify the role of the doctor

### DIFF
--- a/docs/riff.md
+++ b/docs/riff.md
@@ -46,7 +46,7 @@ zero-to-n autoscaling and managed ingress.
 * [riff container](riff_container.md)	 - containers resolve the latest image
 * [riff core](riff_core.md)	 - core runtime for riff workloads
 * [riff credential](riff_credential.md)	 - credentials for container registries
-* [riff doctor](riff_doctor.md)	 - check riff's requirements are installed
+* [riff doctor](riff_doctor.md)	 - check riff's permissions
 * [riff function](riff_function.md)	 - functions built from source using function buildpacks
 * [riff knative](riff_knative.md)	 - Knative runtime for riff workloads
 * [riff streaming](riff_streaming.md)	 - (experimental) streaming runtime for riff functions

--- a/docs/riff_doctor.md
+++ b/docs/riff_doctor.md
@@ -4,16 +4,15 @@ title: "riff doctor"
 ---
 ## riff doctor
 
-check riff's requirements are installed
+check riff's permissions
 
 ### Synopsis
 
-Check that riff is installed.
+The doctor checks that the current user has permission to access riff, and riff
+related, resources in a namespace.
 
-The doctor checks that necessary system components are installed and the user
-has access to resources in the namespace.
-
-The doctor is not a tool for monitoring the health of the cluster.
+The doctor is not a tool for monitoring the health of the cluster or the riff
+install.
 
 ```
 riff doctor [flags]

--- a/pkg/riff/commands/doctor.go
+++ b/pkg/riff/commands/doctor.go
@@ -107,14 +107,13 @@ func NewDoctorCommand(ctx context.Context, c *cli.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "doctor",
 		Aliases: []string{"doc"},
-		Short:   "check " + c.Name + "'s requirements are installed",
+		Short:   "check " + c.Name + "'s permissions",
 		Long: strings.TrimSpace(`
-Check that ` + c.Name + ` is installed.
+The doctor checks that the current user has permission to access ` + c.Name + `, and ` + c.Name + `
+related, resources in a namespace.
 
-The doctor checks that necessary system components are installed and the user
-has access to resources in the namespace.
-
-The doctor is not a tool for monitoring the health of the cluster.
+The doctor is not a tool for monitoring the health of the cluster or the ` + c.Name + `
+install.
 `),
 		Example: "riff doctor",
 		PreRunE: cli.ValidateOptions(ctx, opts),


### PR DESCRIPTION
The line "checks that necessary system components are installed" was
intended to indicate which runtimes are installed (core, knative,
streaming), but it has shown to be confusing with checking that the
system is not just installed, but running correctly (which is not in the
doctor's perview).