### PR TITLE
Add container concurrency support for knative deployer

### DIFF
--- a/docs/riff_knative_deployer_create.md
+++ b/docs/riff_knative_deployer_create.md
@@ -53,7 +53,6 @@ riff knative deployer create my-image-deployer --image registry.example.com/my-i
       --tail                           watch deployer logs
       --target-port port               port that the workload listens on for traffic. The value is exposed to the workload as the PORT environment variable
       --wait-timeout duration          duration to wait for the deployer to become ready when watching logs (default "10m")
-
 ```
 
 ### Options inherited from parent commands

--- a/docs/riff_knative_deployer_create.md
+++ b/docs/riff_knative_deployer_create.md
@@ -35,23 +35,25 @@ riff knative deployer create my-image-deployer --image registry.example.com/my-i
 ### Options
 
 ```
-      --application-ref name    name of application to deploy
-      --container-ref name      name of container to deploy
-      --dry-run                 print kubernetes resources to stdout rather than apply them to the cluster, messages normally on stdout will be sent to stderr
-      --env variable            environment variable defined as a key value pair separated by an equals sign, example "--env MY_VAR=my-value" (may be set multiple times)
-      --env-from variable       environment variable from a config map or secret, example "--env-from MY_SECRET_VALUE=secretKeyRef:my-secret-name:key-in-secret", "--env-from MY_CONFIG_MAP_VALUE=configMapKeyRef:my-config-map-name:key-in-config-map" (may be set multiple times)
-      --function-ref name       name of function to deploy
-  -h, --help                    help for create
-      --image image             container image to deploy
-      --ingress-policy policy   ingress policy for network access to the workload, one of "ClusterLocal" or "External" (default "ClusterLocal")
-      --limit-cpu cores         the maximum amount of cpu allowed, in CPU cores (500m = .5 cores)
-      --limit-memory bytes      the maximum amount of memory allowed, in bytes (500Mi = 500MiB = 500 * 1024 * 1024)
-      --max-scale number        maximum number of replicas (default unbounded)
-      --min-scale number        minimum number of replicas (default 0)
-  -n, --namespace name          kubernetes namespace (defaulted from kube config)
-      --tail                    watch deployer logs
-      --target-port port        port that the workload listens on for traffic. The value is exposed to the workload as the PORT environment variable
-      --wait-timeout duration   duration to wait for the deployer to become ready when watching logs (default "10m")
+      --application-ref name           name of application to deploy
+      --container-concurrency number   the maximum number of concurrent requests to send to a replica at one time
+      --container-ref name             name of container to deploy
+      --dry-run                        print kubernetes resources to stdout rather than apply them to the cluster, messages normally on stdout will be sent to stderr
+      --env variable                   environment variable defined as a key value pair separated by an equals sign, example "--env MY_VAR=my-value" (may be set multiple times)
+      --env-from variable              environment variable from a config map or secret, example "--env-from MY_SECRET_VALUE=secretKeyRef:my-secret-name:key-in-secret", "--env-from MY_CONFIG_MAP_VALUE=configMapKeyRef:my-config-map-name:key-in-config-map" (may be set multiple times)
+      --function-ref name              name of function to deploy
+  -h, --help                           help for create
+      --image image                    container image to deploy
+      --ingress-policy policy          ingress policy for network access to the workload, one of "ClusterLocal" or "External" (default "ClusterLocal")
+      --limit-cpu cores                the maximum amount of cpu allowed, in CPU cores (500m = .5 cores)
+      --limit-memory bytes             the maximum amount of memory allowed, in bytes (500Mi = 500MiB = 500 * 1024 * 1024)
+      --max-scale number               maximum number of replicas (default unbounded)
+      --min-scale number               minimum number of replicas (default 0)
+  -n, --namespace name                 kubernetes namespace (defaulted from kube config)
+      --tail                           watch deployer logs
+      --target-port port               port that the workload listens on for traffic. The value is exposed to the workload as the PORT environment variable
+      --wait-timeout duration          duration to wait for the deployer to become ready when watching logs (default "10m")
+
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -29,6 +29,7 @@ const (
 	ArtifactFlagName              = "--artifact"
 	BootstrapServersFlagName      = "--bootstrap-servers"
 	CacheSizeFlagName             = "--cache-size"
+	ContainerConcurrencyFlagName  = "--container-concurrency"
 	ConfigFlagName                = "--config"
 	ConfigurationRefFlagName      = "--configuration-ref"
 	ContainerRefFlagName          = "--container-ref"

--- a/pkg/validation/concurrency.go
+++ b/pkg/validation/concurrency.go
@@ -22,10 +22,14 @@ import (
 	"github.com/projectriff/cli/pkg/cli"
 )
 
+const (
+	MaxContainerConcurrency int64 = 1000
+)
+
 func ContainerConcurrency(value int64, field string) cli.FieldErrors {
 	errs := cli.FieldErrors{}
 
-	if value < 0 || value > 1000 {
+	if value < 0 || value > MaxContainerConcurrency {
 		errs = errs.Also(cli.ErrInvalidValue(fmt.Sprint(value), field))
 	}
 

--- a/pkg/validation/concurrency.go
+++ b/pkg/validation/concurrency.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package validation
+
+import (
+	"fmt"
+
+	"github.com/projectriff/cli/pkg/cli"
+)
+
+func ContainerConcurrency(value int64, field string) cli.FieldErrors {
+	errs := cli.FieldErrors{}
+
+	if value < 0 || value > 1000 {
+		errs = errs.Also(cli.ErrInvalidValue(fmt.Sprint(value), field))
+	}
+
+	return errs
+}

--- a/pkg/validation/concurrency_test.go
+++ b/pkg/validation/concurrency_test.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package validation_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/projectriff/cli/pkg/cli"
+	rifftesting "github.com/projectriff/cli/pkg/testing"
+	"github.com/projectriff/cli/pkg/validation"
+)
+
+func TestConcurrencyValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected cli.FieldErrors
+		value    int64
+	}{{
+		name:     "valid",
+		expected: cli.FieldErrors{},
+		value:    10,
+	}, {
+		name:     "zero",
+		expected: cli.FieldErrors{},
+		value:    0,
+	}, {
+		name:     "too low",
+		expected: cli.ErrInvalidValue("-1", rifftesting.TestField),
+		value:    -1,
+	}, {
+		name:     "high",
+		expected: cli.FieldErrors{},
+		value:    1000,
+	}, {
+		name:     "too high",
+		expected: cli.ErrInvalidValue("1001", rifftesting.TestField),
+		value:    1001,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			expected := test.expected
+			actual := validation.ContainerConcurrency(test.value, rifftesting.TestField)
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("%s() = (-expected, +actual): %s", test.name, diff)
+			}
+		})
+	}
+}

--- a/pkg/validation/concurrency_test.go
+++ b/pkg/validation/concurrency_test.go
@@ -17,6 +17,7 @@
 package validation_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -48,7 +49,7 @@ func TestConcurrencyValues(t *testing.T) {
 		value:    1000,
 	}, {
 		name:     "too high",
-		expected: cli.ErrInvalidValue("1001", rifftesting.TestField),
+		expected: cli.ErrInvalidValue(fmt.Sprint(validation.MaxContainerConcurrency+1), rifftesting.TestField),
 		value:    1001,
 	}}
 


### PR DESCRIPTION
Adds `--container-concurrency` flag to knative deployer create.

Addresses projectriff/riff#1340