### PR TITLE
Use correct resource names

### DIFF
--- a/pkg/streaming/commands/kafkagateway_create.go
+++ b/pkg/streaming/commands/kafkagateway_create.go
@@ -90,7 +90,7 @@ func (opts *KafkaGatewayCreateOptions) Exec(ctx context.Context, c *cli.Config) 
 	if opts.Tail {
 		err := race.Run(ctx, opts.WaitTimeout,
 			func(ctx context.Context) error {
-				return k8s.WaitUntilReady(ctx, c.StreamingRuntime().RESTClient(), "kafkagatewaies", gateway)
+				return k8s.WaitUntilReady(ctx, c.StreamingRuntime().RESTClient(), "kafkagateways", gateway)
 			},
 			func(ctx context.Context) error {
 				return c.Kail.KafkaGatewayLogs(ctx, gateway, cli.TailSinceCreateDefault, c.Stdout)

--- a/pkg/streaming/commands/pulsargateway_create.go
+++ b/pkg/streaming/commands/pulsargateway_create.go
@@ -90,7 +90,7 @@ func (opts *PulsarGatewayCreateOptions) Exec(ctx context.Context, c *cli.Config)
 	if opts.Tail {
 		err := race.Run(ctx, opts.WaitTimeout,
 			func(ctx context.Context) error {
-				return k8s.WaitUntilReady(ctx, c.StreamingRuntime().RESTClient(), "pulsargatewaies", gateway)
+				return k8s.WaitUntilReady(ctx, c.StreamingRuntime().RESTClient(), "pulsargateways", gateway)
 			},
 			func(ctx context.Context) error {
 				return c.Kail.PulsarGatewayLogs(ctx, gateway, cli.TailSinceCreateDefault, c.Stdout)


### PR DESCRIPTION
Tests with fake clients need to use the `gatewaies` misspelling, but the real client should use the correct spelling.