### PR TITLE
Support in-cluster kubeconfig

### DIFF
--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/fatih/color"
@@ -140,13 +139,6 @@ func (c *Config) initKubeConfig() {
 	}
 	if kubeEnvConf, ok := os.LookupEnv("KUBECONFIG"); ok {
 		c.KubeConfigFile = kubeEnvConf
-	} else {
-		home, err := homedir.Dir()
-		if err != nil {
-			c.Errorf("%s\n", err)
-			os.Exit(1)
-		}
-		c.KubeConfigFile = filepath.Join(home, ".kube", "config")
 	}
 }
 

--- a/pkg/cli/config_pkg_test.go
+++ b/pkg/cli/config_pkg_test.go
@@ -19,7 +19,6 @@ package cli
 import (
 	"bytes"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -132,37 +131,6 @@ func TestInitKubeConfig_EnvVar(t *testing.T) {
 	c.initKubeConfig()
 
 	if expected, actual := "testdata/.kube/config", c.KubeConfigFile; expected != actual {
-		t.Errorf("Expected kubeconfig path %q, actually %q", expected, actual)
-	}
-	if diff := cmp.Diff("", strings.TrimSpace(output.String())); diff != "" {
-		t.Errorf("Unexpected output (-expected, +actual): %s", diff)
-	}
-}
-
-func TestInitKubeConfig_HomeDir(t *testing.T) {
-	noColor := color.NoColor
-	color.NoColor = false
-	defer func() { color.NoColor = noColor }()
-
-	home, homeisset := os.LookupEnv("HOME")
-	defer func() {
-		homedir.Reset()
-		if homeisset {
-			os.Setenv("HOME", home)
-		} else {
-			os.Unsetenv("HOME")
-		}
-	}()
-
-	c := NewDefaultConfig()
-	output := &bytes.Buffer{}
-	c.Stdout = output
-	c.Stderr = output
-
-	os.Setenv("HOME", "testdata")
-	c.initKubeConfig()
-
-	if expected, actual := filepath.FromSlash("testdata/.kube/config"), c.KubeConfigFile; expected != actual {
 		t.Errorf("Expected kubeconfig path %q, actually %q", expected, actual)
 	}
 	if diff := cmp.Diff("", strings.TrimSpace(output.String())); diff != "" {

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -29,7 +29,6 @@ import (
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 type Client interface {
@@ -96,10 +95,10 @@ type client struct {
 
 func (c *client) lazyLoadKubeConfig() clientcmd.ClientConfig {
 	if c.kubeConfig == nil {
-		c.kubeConfig = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-			&clientcmd.ClientConfigLoadingRules{ExplicitPath: c.kubeConfigFile},
-			&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: ""}},
-		)
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		loadingRules.ExplicitPath = c.kubeConfigFile
+		configOverrides := &clientcmd.ConfigOverrides{}
+		c.kubeConfig = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 	}
 	return c.kubeConfig
 }


### PR DESCRIPTION
Removed explicit support for loading from the user's home directory. The
default loading rules will discover an in-cluster or user's config
correctly without intervention. A user can still specify an explicit
path to a kubeconfig file.

Fixes #198