### PR TITLE
Log when waiting for a resource to become ready

### DIFF
--- a/pkg/build/commands/application_create.go
+++ b/pkg/build/commands/application_create.go
@@ -226,6 +226,7 @@ func (opts *ApplicationCreateOptions) Exec(ctx context.Context, c *cli.Config) e
 	}
 	c.Successf("Created application %q\n", application.Name)
 	if opts.Tail {
+		c.Infof("Waiting for application %q to become ready...\n", application.Name)
 		// err guarded by Validate()
 		timeout, _ := time.ParseDuration(opts.WaitTimeout)
 		err := race.Run(ctx, timeout,

--- a/pkg/build/commands/application_create_test.go
+++ b/pkg/build/commands/application_create_test.go
@@ -920,6 +920,7 @@ Created application "my-application"
 			},
 			ExpectOutput: `
 Created application "my-application"
+Waiting for application "my-application" to become ready...
 ...log output...
 Application "my-application" is ready
 `,
@@ -983,6 +984,7 @@ Application "my-application" is ready
 			},
 			ExpectOutput: `
 Created application "my-application"
+Waiting for application "my-application" to become ready...
 ...log output...
 Timeout after "5ms" waiting for "my-application" to become ready
 To view status run: riff application list --namespace default
@@ -1047,6 +1049,10 @@ To continue watching logs run: riff application tail my-application --namespace 
 					},
 				},
 			},
+			ExpectOutput: `
+Created application "my-application"
+Waiting for application "my-application" to become ready...
+`,
 			ShouldError: true,
 		},
 	}

--- a/pkg/build/commands/container_create.go
+++ b/pkg/build/commands/container_create.go
@@ -94,6 +94,7 @@ func (opts *ContainerCreateOptions) Exec(ctx context.Context, c *cli.Config) err
 	}
 	c.Successf("Created container %q\n", container.Name)
 	if opts.Tail {
+		c.Infof("Waiting for container %q to become ready...\n", container.Name)
 		// err guarded by Validate()
 		timeout, _ := time.ParseDuration(opts.WaitTimeout)
 		err := race.Run(ctx, timeout,

--- a/pkg/build/commands/container_create_test.go
+++ b/pkg/build/commands/container_create_test.go
@@ -243,6 +243,7 @@ Created container "my-container"
 			},
 			ExpectOutput: `
 Created container "my-container"
+Waiting for container "my-container" to become ready...
 ...log output...
 Container "my-container" is ready
 `,
@@ -276,6 +277,7 @@ Container "my-container" is ready
 			},
 			ExpectOutput: `
 Created container "my-container"
+Waiting for container "my-container" to become ready...
 Timeout after "5ms" waiting for "my-container" to become ready
 To view status run: riff container list --namespace default
 To continue watching logs run: riff container tail my-container --namespace default
@@ -315,6 +317,10 @@ To continue watching logs run: riff container tail my-container --namespace defa
 					},
 				},
 			},
+			ExpectOutput: `
+Created container "my-container"
+Waiting for container "my-container" to become ready...
+`,
 			ShouldError: true,
 		},
 	}

--- a/pkg/build/commands/function_create.go
+++ b/pkg/build/commands/function_create.go
@@ -240,6 +240,7 @@ func (opts *FunctionCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 	}
 	c.Successf("Created function %q\n", function.Name)
 	if opts.Tail {
+		c.Infof("Waiting for function %q to become ready...\n", function.Name)
 		// err guarded by Validate()
 		timeout, _ := time.ParseDuration(opts.WaitTimeout)
 		err := race.Run(ctx, timeout,

--- a/pkg/build/commands/function_create_test.go
+++ b/pkg/build/commands/function_create_test.go
@@ -959,6 +959,7 @@ Created function "my-function"
 			},
 			ExpectOutput: `
 Created function "my-function"
+Waiting for function "my-function" to become ready...
 ...log output...
 Function "my-function" is ready
 `,
@@ -1022,6 +1023,7 @@ Function "my-function" is ready
 			},
 			ExpectOutput: `
 Created function "my-function"
+Waiting for function "my-function" to become ready...
 ...log output...
 Timeout after "5ms" waiting for "my-function" to become ready
 To view status run: riff function list --namespace default
@@ -1086,6 +1088,10 @@ To continue watching logs run: riff function tail my-function --namespace defaul
 					},
 				},
 			},
+			ExpectOutput: `
+Created function "my-function"
+Waiting for function "my-function" to become ready...
+`,
 			ShouldError: true,
 		},
 	}

--- a/pkg/core/commands/deployer_create.go
+++ b/pkg/core/commands/deployer_create.go
@@ -212,6 +212,7 @@ func (opts *DeployerCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 	}
 	c.Successf("Created deployer %q\n", deployer.Name)
 	if opts.Tail {
+		c.Infof("Waiting for deployer %q to become ready...\n", deployer.Name)
 		// err guarded by Validate()
 		timeout, _ := time.ParseDuration(opts.WaitTimeout)
 		err := race.Run(ctx, timeout,

--- a/pkg/core/commands/deployer_create_test.go
+++ b/pkg/core/commands/deployer_create_test.go
@@ -659,6 +659,7 @@ Created deployer "my-deployer"
 			},
 			ExpectOutput: `
 Created deployer "my-deployer"
+Waiting for deployer "my-deployer" to become ready...
 ...log output...
 Deployer "my-deployer" is ready
 `,
@@ -720,6 +721,7 @@ Deployer "my-deployer" is ready
 			},
 			ExpectOutput: `
 Created deployer "my-deployer"
+Waiting for deployer "my-deployer" to become ready...
 ...log output...
 Timeout after "5ms" waiting for "my-deployer" to become ready
 To view status run: riff core deployer list --namespace default
@@ -782,6 +784,10 @@ To continue watching logs run: riff core deployer tail my-deployer --namespace d
 					},
 				},
 			},
+			ExpectOutput: `
+Created deployer "my-deployer"
+Waiting for deployer "my-deployer" to become ready...
+`,
 			ShouldError: true,
 		},
 	}

--- a/pkg/knative/commands/adapter_create.go
+++ b/pkg/knative/commands/adapter_create.go
@@ -170,6 +170,7 @@ func (opts *AdapterCreateOptions) Exec(ctx context.Context, c *cli.Config) error
 	}
 	c.Successf("Created adapter %q\n", adapter.Name)
 	if opts.Tail {
+		c.Infof("Waiting for adapter %q to become ready...\n", adapter.Name)
 		// err guarded by Validate()
 		timeout, _ := time.ParseDuration(opts.WaitTimeout)
 		err := race.Run(ctx, timeout,

--- a/pkg/knative/commands/adapter_create_test.go
+++ b/pkg/knative/commands/adapter_create_test.go
@@ -407,6 +407,7 @@ Created adapter "my-adapter"
 			},
 			ExpectOutput: `
 Created adapter "my-adapter"
+Waiting for adapter "my-adapter" to become ready...
 ...log output...
 Adapter "my-adapter" is ready
 `,
@@ -445,6 +446,7 @@ Adapter "my-adapter" is ready
 			},
 			ExpectOutput: `
 Created adapter "my-adapter"
+Waiting for adapter "my-adapter" to become ready...
 Timeout after "5ms" waiting for "my-adapter" to become ready
 To view status run: riff knative adapter list --namespace default
 `,
@@ -488,6 +490,10 @@ To view status run: riff knative adapter list --namespace default
 					},
 				},
 			},
+			ExpectOutput: `
+Created adapter "my-adapter"
+Waiting for adapter "my-adapter" to become ready...
+`,
 			ShouldError: true,
 		},
 	}

--- a/pkg/knative/commands/deployer_create.go
+++ b/pkg/knative/commands/deployer_create.go
@@ -245,6 +245,7 @@ func (opts *DeployerCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 	}
 	c.Successf("Created deployer %q\n", deployer.Name)
 	if opts.Tail {
+		c.Infof("Waiting for deployer %q to become ready...\n", deployer.Name)
 		// err guarded by Validate()
 		timeout, _ := time.ParseDuration(opts.WaitTimeout)
 		err := race.Run(ctx, timeout,

--- a/pkg/knative/commands/deployer_create_test.go
+++ b/pkg/knative/commands/deployer_create_test.go
@@ -886,6 +886,7 @@ Created deployer "my-deployer"
 			},
 			ExpectOutput: `
 Created deployer "my-deployer"
+Waiting for deployer "my-deployer" to become ready...
 ...log output...
 Deployer "my-deployer" is ready
 `,
@@ -947,6 +948,7 @@ Deployer "my-deployer" is ready
 			},
 			ExpectOutput: `
 Created deployer "my-deployer"
+Waiting for deployer "my-deployer" to become ready...
 ...log output...
 Timeout after "5ms" waiting for "my-deployer" to become ready
 To view status run: riff knative deployer list --namespace default
@@ -1009,6 +1011,10 @@ To continue watching logs run: riff knative deployer tail my-deployer --namespac
 					},
 				},
 			},
+			ExpectOutput: `
+Created deployer "my-deployer"
+Waiting for deployer "my-deployer" to become ready...
+`,
 			ShouldError: true,
 		},
 	}

--- a/pkg/streaming/commands/inmemorygateway_create.go
+++ b/pkg/streaming/commands/inmemorygateway_create.go
@@ -81,6 +81,7 @@ func (opts *InMemoryGatewayCreateOptions) Exec(ctx context.Context, c *cli.Confi
 	}
 	c.Successf("Created in-memory gateway %q\n", gateway.Name)
 	if opts.Tail {
+		c.Infof("Waiting for in-memory gateway %q to become ready...\n", gateway.Name)
 		err := race.Run(ctx, opts.WaitTimeout,
 			func(ctx context.Context) error {
 				return k8s.WaitUntilReady(ctx, c.StreamingRuntime().RESTClient(), "inmemorygateways", gateway)

--- a/pkg/streaming/commands/inmemorygateway_create_test.go
+++ b/pkg/streaming/commands/inmemorygateway_create_test.go
@@ -197,6 +197,7 @@ Created in-memory gateway "my-inmemory-gateway"
 			},
 			ExpectOutput: `
 Created in-memory gateway "franz"
+Waiting for in-memory gateway "franz" to become ready...
 ...log output...
 InMemoryGateway "franz" is ready
 `,
@@ -243,6 +244,7 @@ InMemoryGateway "franz" is ready
 			},
 			ExpectOutput: `
 Created in-memory gateway "franz"
+Waiting for in-memory gateway "franz" to become ready...
 ...log output...
 Timeout after "7ms" waiting for "franz" to become ready
 To view status run: riff streaming inmemory-gateway list --namespace default
@@ -293,6 +295,7 @@ To view status run: riff streaming inmemory-gateway list --namespace default
 			ShouldError: true,
 			ExpectOutput: `
 Created in-memory gateway "franz"
+Waiting for in-memory gateway "franz" to become ready...
 `,
 		},
 	}

--- a/pkg/streaming/commands/kafkagateway_create.go
+++ b/pkg/streaming/commands/kafkagateway_create.go
@@ -88,6 +88,7 @@ func (opts *KafkaGatewayCreateOptions) Exec(ctx context.Context, c *cli.Config) 
 	}
 	c.Successf("Created kafka gateway %q\n", gateway.Name)
 	if opts.Tail {
+		c.Infof("Waiting for kafka gateway %q to become ready...\n", gateway.Name)
 		err := race.Run(ctx, opts.WaitTimeout,
 			func(ctx context.Context) error {
 				return k8s.WaitUntilReady(ctx, c.StreamingRuntime().RESTClient(), "kafkagateways", gateway)

--- a/pkg/streaming/commands/kafkagateway_create_test.go
+++ b/pkg/streaming/commands/kafkagateway_create_test.go
@@ -222,6 +222,7 @@ Created kafka gateway "my-kafka-gateway"
 			},
 			ExpectOutput: `
 Created kafka gateway "franz"
+Waiting for kafka gateway "franz" to become ready...
 ...log output...
 KafkaGateway "franz" is ready
 `,
@@ -272,6 +273,7 @@ KafkaGateway "franz" is ready
 			},
 			ExpectOutput: `
 Created kafka gateway "franz"
+Waiting for kafka gateway "franz" to become ready...
 ...log output...
 Timeout after "7ms" waiting for "franz" to become ready
 To view status run: riff streaming kafka-gateway list --namespace default
@@ -326,6 +328,7 @@ To view status run: riff streaming kafka-gateway list --namespace default
 			ShouldError: true,
 			ExpectOutput: `
 Created kafka gateway "franz"
+Waiting for kafka gateway "franz" to become ready...
 `,
 		},
 	}

--- a/pkg/streaming/commands/processor_create.go
+++ b/pkg/streaming/commands/processor_create.go
@@ -181,6 +181,7 @@ func (opts *ProcessorCreateOptions) Exec(ctx context.Context, c *cli.Config) err
 	}
 	c.Successf("Created processor %q\n", processor.Name)
 	if opts.Tail {
+		c.Infof("Waiting for processor %q to become ready...\n", processor.Name)
 		// err guarded by Validate()
 		timeout, _ := time.ParseDuration(opts.WaitTimeout)
 		err := race.Run(ctx, timeout,

--- a/pkg/streaming/commands/processor_create_test.go
+++ b/pkg/streaming/commands/processor_create_test.go
@@ -601,6 +601,7 @@ Created processor "my-processor"
 			},
 			ExpectOutput: `
 Created processor "my-processor"
+Waiting for processor "my-processor" to become ready...
 ...log output...
 Processor "my-processor" is ready
 `,
@@ -670,6 +671,7 @@ Processor "my-processor" is ready
 			},
 			ExpectOutput: `
 Created processor "my-processor"
+Waiting for processor "my-processor" to become ready...
 ...log output...
 Timeout after "5ms" waiting for "my-processor" to become ready
 To view status run: riff processor list --namespace default
@@ -740,6 +742,10 @@ To continue watching logs run: riff processor tail my-processor --namespace defa
 					},
 				},
 			},
+			ExpectOutput: `
+Created processor "my-processor"
+Waiting for processor "my-processor" to become ready...
+`,
 			ShouldError: true,
 		},
 		{

--- a/pkg/streaming/commands/pulsargateway_create.go
+++ b/pkg/streaming/commands/pulsargateway_create.go
@@ -88,6 +88,7 @@ func (opts *PulsarGatewayCreateOptions) Exec(ctx context.Context, c *cli.Config)
 	}
 	c.Successf("Created pulsar gateway %q\n", gateway.Name)
 	if opts.Tail {
+		c.Infof("Waiting for pulsar gateway %q to become ready...\n", gateway.Name)
 		err := race.Run(ctx, opts.WaitTimeout,
 			func(ctx context.Context) error {
 				return k8s.WaitUntilReady(ctx, c.StreamingRuntime().RESTClient(), "pulsargateways", gateway)

--- a/pkg/streaming/commands/pulsargateway_create_test.go
+++ b/pkg/streaming/commands/pulsargateway_create_test.go
@@ -222,6 +222,7 @@ Created pulsar gateway "my-pulsar-gateway"
 			},
 			ExpectOutput: `
 Created pulsar gateway "franz"
+Waiting for pulsar gateway "franz" to become ready...
 ...log output...
 PulsarGateway "franz" is ready
 `,
@@ -272,6 +273,7 @@ PulsarGateway "franz" is ready
 			},
 			ExpectOutput: `
 Created pulsar gateway "franz"
+Waiting for pulsar gateway "franz" to become ready...
 ...log output...
 Timeout after "7ms" waiting for "franz" to become ready
 To view status run: riff streaming pulsar-gateway list --namespace default
@@ -326,6 +328,7 @@ To view status run: riff streaming pulsar-gateway list --namespace default
 			ShouldError: true,
 			ExpectOutput: `
 Created pulsar gateway "franz"
+Waiting for pulsar gateway "franz" to become ready...
 `,
 		},
 	}

--- a/pkg/streaming/commands/stream_create.go
+++ b/pkg/streaming/commands/stream_create.go
@@ -97,6 +97,7 @@ func (opts *StreamCreateOptions) Exec(ctx context.Context, c *cli.Config) error 
 	}
 	c.Successf("Created stream %q\n", stream.Name)
 	if opts.Tail {
+		c.Infof("Waiting for stream %q to become ready...\n", stream.Name)
 		err := race.Run(ctx, opts.WaitTimeout,
 			func(ctx context.Context) error {
 				return k8s.WaitUntilReady(ctx, c.StreamingRuntime().RESTClient(), "streams", stream)

--- a/pkg/streaming/commands/stream_create_test.go
+++ b/pkg/streaming/commands/stream_create_test.go
@@ -276,6 +276,7 @@ Created stream "my-stream"
 			},
 			ExpectOutput: `
 Created stream "input"
+Waiting for stream "input" to become ready...
 Stream "input" is ready
 `,
 		},
@@ -310,6 +311,7 @@ Stream "input" is ready
 			ShouldError: true,
 			ExpectOutput: `
 Created stream "input"
+Waiting for stream "input" to become ready...
 Timeout after "10ms" waiting for "input" to become ready
 To view status run: riff streaming stream list --namespace default
 `,


### PR DESCRIPTION
When creating a resource the `--tail` flag will block until the resource
becomes ready (or not). Many resources have logs that will be displayed,
but not all. Even for resources will logs, it may take a moment for logs
to start being produced.

Now we log when waiting for a resource to become ready.