### PR TITLE
Make white labeling even easier

### DIFF
--- a/.github/workflows/stage.sh
+++ b/.github/workflows/stage.sh
@@ -15,4 +15,4 @@ make release
 
 bucket=gs://projectriff/riff-cli/releases
 
-gsutil cp -a public-read -n riff-*{.tgz,.zip} ${bucket}/builds/v${slug}/
+gsutil cp -a public-read -n dist/riff-*{.tgz,.zip} ${bucket}/builds/v${slug}/

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 # built artifacts
-/riff
-/riff.zip
-/riff-*.tgz
-/riff-*.zip
+/bin
+/dist
 
 # coverage artifacts
 /coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-OUTPUT = ./riff
+NAME ?= riff
+OUTPUT = ./bin/$(NAME)
 GO_SOURCES = $(shell find . -type f -name '*.go')
 GOBIN ?= $(shell go env GOPATH)/bin
 VERSION ?= $(shell cat VERSION)
 GITSHA = $(shell git rev-parse HEAD)
 GITDIRTY = $(shell git diff --quiet HEAD || echo "dirty")
-LDFLAGS_VERSION = -X github.com/projectriff/cli/pkg/cli.cli_name=riff \
+LDFLAGS_VERSION = -X github.com/projectriff/cli/pkg/cli.cli_name=$(NAME) \
 				  -X github.com/projectriff/cli/pkg/cli.cli_version=$(VERSION) \
 				  -X github.com/projectriff/cli/pkg/cli.cli_gitsha=$(GITSHA) \
 				  -X github.com/projectriff/cli/pkg/cli.cli_gitdirty=$(GITDIRTY) \
@@ -15,10 +16,8 @@ all: build test verify-goimports docs ## Build, test, verify source formatting a
 
 .PHONY: clean
 clean: ## Delete build output
-	rm -f $(OUTPUT)
-	rm -f riff-darwin-amd64.tgz
-	rm -f riff-linux-amd64.tgz
-	rm -f riff-windows-amd64.zip
+	rm -f bin/
+	rm -f dist/
 
 .PHONY: build
 build: $(OUTPUT) ## Build riff
@@ -52,9 +51,9 @@ $(OUTPUT): $(GO_SOURCES) VERSION
 
 .PHONY: release
 release: $(GO_SOURCES) VERSION ## Cross-compile riff for various operating systems
-	GOOS=darwin   GOARCH=amd64 go build -ldflags "$(LDFLAGS_VERSION)" -o $(OUTPUT)     ./cmd/riff && tar -czf riff-darwin-amd64.tgz  $(OUTPUT)     && rm -f $(OUTPUT)
-	GOOS=linux    GOARCH=amd64 go build -ldflags "$(LDFLAGS_VERSION)" -o $(OUTPUT)     ./cmd/riff && tar -czf riff-linux-amd64.tgz   $(OUTPUT)     && rm -f $(OUTPUT)
-	GOOS=windows  GOARCH=amd64 go build -ldflags "$(LDFLAGS_VERSION)" -o $(OUTPUT).exe ./cmd/riff && zip -mq  riff-windows-amd64.zip $(OUTPUT).exe && rm -f $(OUTPUT).exe
+	GOOS=darwin   GOARCH=amd64 go build -ldflags "$(LDFLAGS_VERSION)" -o $(OUTPUT)     ./cmd/riff && tar -czf dist/$(NAME)-darwin-amd64.tgz  $(OUTPUT)     && rm -f $(OUTPUT)
+	GOOS=linux    GOARCH=amd64 go build -ldflags "$(LDFLAGS_VERSION)" -o $(OUTPUT)     ./cmd/riff && tar -czf dist/$(NAME)-linux-amd64.tgz   $(OUTPUT)     && rm -f $(OUTPUT)
+	GOOS=windows  GOARCH=amd64 go build -ldflags "$(LDFLAGS_VERSION)" -o $(OUTPUT).exe ./cmd/riff && zip -mq  dist/$(NAME)-windows-amd64.zip $(OUTPUT).exe && rm -f $(OUTPUT).exe
 
 docs: $(OUTPUT) clean-docs ## Generate documentation
 	$(OUTPUT) docs


### PR DESCRIPTION
Creating a white labeled build of the riff cli is now possible:

    NAME=ostinato make build

Produces a binary at `./bin/ostinato`

The path within the project for built binaries has moved to `./bin/riff`
and for packaged artifacts to `./dist/riff-linux-amd64.tgz`. The bin and
dist directories are ignored from git.