### PR TITLE
Allow specifying the docker container's network for local builds

### DIFF
--- a/.github/workflows/acceptance.sh
+++ b/.github/workflows/acceptance.sh
@@ -118,7 +118,7 @@ if [ "$machine" != "MinGw" ]; then
     echo "##[group]Run function $name"
 
     riff function create $name --image $image --namespace $NAMESPACE --tail \
-      --local-path $fats_dir/functions/uppercase/${test} &
+      --local-path $fats_dir/functions/uppercase/${test} --docker-network host &
 
     riff core deployer create $name \
       --function-ref $name \

--- a/pkg/build/commands/application_create.go
+++ b/pkg/build/commands/application_create.go
@@ -44,7 +44,9 @@ type ApplicationCreateOptions struct {
 	Image     string
 	CacheSize string
 
-	LocalPath   string
+	LocalPath     string
+	DockerNetwork string
+
 	GitRepo     string
 	GitRevision string
 	SubPath     string
@@ -209,6 +211,9 @@ func (opts *ApplicationCreateOptions) Exec(ctx context.Context, c *cli.Config) e
 			Builder: builder,
 			Env:     env,
 			Publish: true,
+			ContainerConfig: pack.ContainerConfig{
+				Network: opts.DockerNetwork,
+			},
 		})
 		if err != nil {
 			return err
@@ -288,6 +293,8 @@ cluster).
 	cmd.Flags().StringVar(&opts.CacheSize, cli.StripDash(cli.CacheSizeFlagName), "", "`size` of persistent volume to cache resources between builds")
 	cmd.Flags().StringVar(&opts.LocalPath, cli.StripDash(cli.LocalPathFlagName), "", "path to `directory` containing source code on the local machine")
 	_ = cmd.MarkFlagDirname(cli.StripDash(cli.LocalPathFlagName))
+	cmd.Flags().StringVar(&opts.DockerNetwork, "docker-network", "", "network for local build containers")
+	cmd.Flags().MarkHidden("docker-network")
 	cmd.Flags().StringVar(&opts.GitRepo, cli.StripDash(cli.GitRepoFlagName), "", "git `url` to remote source code")
 	cmd.Flags().StringVar(&opts.GitRevision, cli.StripDash(cli.GitRevisionFlagName), "master", "`refspec` within the git repo to checkout")
 	cmd.Flags().StringVar(&opts.SubPath, cli.StripDash(cli.SubPathFlagName), "", "path to `directory` within the git repo to checkout")

--- a/pkg/build/commands/function_create.go
+++ b/pkg/build/commands/function_create.go
@@ -48,7 +48,9 @@ type FunctionCreateOptions struct {
 	Handler  string
 	Invoker  string
 
-	LocalPath   string
+	LocalPath     string
+	DockerNetwork string
+
 	GitRepo     string
 	GitRevision string
 	SubPath     string
@@ -223,6 +225,9 @@ func (opts *FunctionCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 			Builder: builder,
 			Env:     env,
 			Publish: true,
+			ContainerConfig: pack.ContainerConfig{
+				Network: opts.DockerNetwork,
+			},
 		})
 		if err != nil {
 			return err
@@ -323,6 +328,8 @@ The riff.toml file takes the form:
 	cmd.Flags().StringVar(&opts.Invoker, cli.StripDash(cli.InvokerFlagName), "", "language runtime invoker `name` (detected by default)")
 	cmd.Flags().StringVar(&opts.LocalPath, cli.StripDash(cli.LocalPathFlagName), "", "path to `directory` containing source code on the local machine")
 	_ = cmd.MarkFlagDirname(cli.StripDash(cli.LocalPathFlagName))
+	cmd.Flags().StringVar(&opts.DockerNetwork, "docker-network", "", "network for local build containers")
+	cmd.Flags().MarkHidden("docker-network")
 	cmd.Flags().StringVar(&opts.GitRepo, cli.StripDash(cli.GitRepoFlagName), "", "git `url` to remote source code")
 	cmd.Flags().StringVar(&opts.GitRevision, cli.StripDash(cli.GitRevisionFlagName), "master", "`refspec` within the git repo to checkout")
 	cmd.Flags().StringVar(&opts.SubPath, cli.StripDash(cli.SubPathFlagName), "", "path to `directory` within the git repo to checkout")


### PR DESCRIPTION
Pack 0.11 changed the default container network from host to bridged
for the analyze and export containers. This breaks local builds that use
a registry DNS entry defined in /etc/hosts (like our acceptance test
sometimes do).

This adds a new flag, --docker-network, when creating a function or
application with a local path to set the docker network. The flag is
hidden and not unit tested.